### PR TITLE
Buck build support

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,0 +1,2 @@
+[project]
+  ignore = .git

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,10 @@ sodium
 donna
 speed
 rename_*
+
+# Buck
+/buck-out/
+/.buckd/
+/buckaroo/
+.buckconfig.local
+BUCKAROO_DEPS

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,12 @@
+cxx_library(
+  name = 'monocypher',
+  exported_headers = subdir_glob([
+    ('src', '**/*.h'),
+  ]),
+  srcs = glob([
+    'src/**/*.c',
+  ]),
+  visibility = [
+    'PUBLIC',
+  ],
+)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ just copy `src/monocypher.h` and `src/monocypher.c` into your project.
 They compile as C99, C11, C++98, C++11, C++14, and C++17. (Tested with
 gcc 5.4.0 and clang 2.8.0 on GNU/Linux.)
 
+Or, using [Buckaroo](https://buckaroo.pm):
+
+    $ buckaroo install github+loupvaillant/monocypher
+
 Test suite
 ----------
 

--- a/buckaroo.json
+++ b/buckaroo.json
@@ -1,0 +1,4 @@
+{
+  "name": "Monocypher",
+  "target": "monocypher"
+}


### PR DESCRIPTION
This PR adds support for builds using [Buck](https://buckbuild.com/).

To build the library:

```bash=
buck build :monocypher
```

The existing Make build is unchanged; the two can coexist peacefully 😊