### PR TITLE
Document minimum libsodium version for test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Test suite
 
 It should display a nice printout of all the tests, all starting with
 "OK".  If you see "FAILURE" anywhere, something has gone very wrong
-somewhere.  Note: the fuzz tests depend on libsodium.  Install it
-before you run them.
+somewhere.  Note: the fuzz tests depend on libsodium 1.0.12 or above.
+Install it before you run them.
 
 To run only the self contained tests, run
 


### PR DESCRIPTION
Turns out, [Debian stretch ships with 1.0.11](https://packages.debian.org/stretch/libsodium18), which lacks the required `crypto_stream_xchacha20_xor_ic` function.