### PR TITLE
Create all installation directories

### DIFF
--- a/makefile
+++ b/makefile
@@ -28,7 +28,7 @@ MAN_DIR=$(DESTDIR)/$(PREFIX)/share/man/man3
 
 all    : library
 install: library src/monocypher.h install-doc
-	mkdir -p $(DESTDIR)/$(PREFIX)/lib
+	mkdir -p $(DESTDIR)/$(PREFIX)/lib $(DESTDIR)/$(PREFIX)/include $(PKGCONFIG) $(MAN_DIR)
 	cp lib/libmonocypher.a lib/libmonocypher.so $(DESTDIR)/$(PREFIX)/lib
 	cp src/monocypher.h $(DESTDIR)/$(PREFIX)/include
 	@echo "Creating $(PKGCONFIG)/monocypher.pc"


### PR DESCRIPTION
This is required for the `DESTDIR` variable to actually work and create the necessary tree.