### PR TITLE
Fix link generation in HTML man page conversion

### DIFF
--- a/doc/man2html.sh
+++ b/doc/man2html.sh
@@ -5,7 +5,7 @@ mkdir -p html
 for name in $(ls -1 "man/man3/" | sed 's/.3monocypher//' | grep -v "style.css")
 do
     mandoc                         \
-        -Oman=%N.%S.html           \
+        -Oman=%N.html              \
         -Ostyle=style.css \
         -Thtml man/man3/$name.3monocypher > html/$name.html
 done


### PR DESCRIPTION
We strip the ".3monocypher" from the filename, so the `-Oman` argument needs to reflect that.