### PR TITLE
Fix mandoc invocation for recent mandoc versions

### DIFF
--- a/doc/man2html.sh
+++ b/doc/man2html.sh
@@ -4,9 +4,8 @@ mkdir -p html
 
 for name in $(ls -1 "man/man3/" | sed 's/.3monocypher//' | grep -v "style.css")
 do
-    mandoc                         \
-        -Oman=%N.html              \
-        -Ostyle=style.css \
+    mandoc                            \
+        -Oman=%N.html,style=style.css \
         -Thtml man/man3/$name.3monocypher > html/$name.html
 done
 


### PR DESCRIPTION
A commit in mandoc earlier this year subtly broke the `-O` parsing.
Multiple instances of `-O` do not get parsed, so all options have to be passed into the same `-O` with comma separation as intended.

Presumably caused by [this commit](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/mandoc/main.c.diff?r1=1.185&r2=1.186&f=h).