### PR TITLE
Recommend BCryptGenRandom on Windows

### DIFF
--- a/doc/man/man3/intro.3monocypher
+++ b/doc/man/man3/intro.3monocypher
@@ -146,7 +146,7 @@ This is easier to use than
 .Fn getrandom .
 .It
 Windows provides
-.Fn CryptGenRandom .
+.Fn BCryptGenRandom .
 .El
 .Pp
 The


### PR DESCRIPTION
CryptGenRandom is deprecated. The replacement seems to be [BCryptGenRandom](https://docs.microsoft.com/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgenrandom).

See https://docs.microsoft.com/en-us/windows/desktop/api/wincrypt/nf-wincrypt-cryptgenrandom:

> **Important** This API is deprecated. New and existing software should start using [Cryptography Next Generation APIs](https://msdn.microsoft.com/en-us/library/windows/desktop/aa376210%28v=vs.85%29.aspx). Microsoft may remove this API in future releases.