### PR TITLE
man: fix whitespace and macro invocation issues

### DIFF
--- a/doc/man/man3/crypto_kex_x_init_client.3monocypher
+++ b/doc/man/man3/crypto_kex_x_init_client.3monocypher
@@ -106,7 +106,7 @@ The public key of the server.
 .El
 .Pp
 After creating initialising
-.Fa ctx , 
+.Fa ctx ,
 the client calls
 .Fn crypto_kex_x_1
 to generate
@@ -134,7 +134,7 @@ only once the handshake completes,
 which is application logic and not part of the key exchange protocol.
 .Pp
 After initialising
-.Fa ctx , 
+.Fa ctx ,
 the server waits for the client to send
 .Fa msg1
 and reads it from the network.
@@ -161,7 +161,7 @@ This function also wipes the data in
 and
 .Fn crypto_kex_x_1
 return nothing.
-.PP
+.Pp
 .Fn crypto_kex_x_2
 returns 0 on success or -1 if the messages were corrupt or mismatched the
 server's identity.
@@ -178,7 +178,7 @@ Client:
 .Bd -literal -offset indent
 crypto_kex_ctx client_ctx; /* key exchange context */
 uint8_t sk[32];            /* 32 random bytes long-term secret key */
-uint8_t their_pk[32];      /* the server's public key 
+uint8_t their_pk[32];      /* the server's public key
                             * (known ahead of time) */
 uint8_t seed[32];          /* 32 random bytes */
 uint8_t buf[80];           /* buffer for the key exchange messages */

--- a/doc/man/man3/crypto_kex_xk1_init_client.3monocypher
+++ b/doc/man/man3/crypto_kex_xk1_init_client.3monocypher
@@ -121,7 +121,7 @@ This is used to authenticate the server's identity.
 .El
 .Pp
 After initialising
-.Fa ctx , 
+.Fa ctx ,
 the client calls
 .Fn crypto_kex_xk1_1
 to generate
@@ -167,7 +167,7 @@ and
 are generated ahead of time and known to the clients.
 .Pp
 After initialising
-.Fa ctx , 
+.Fa ctx ,
 the server waits for the client to send
 .Fa msg1
 and reads it from the network.
@@ -224,7 +224,7 @@ Client:
 .Bd -literal -offset indent
 crypto_kex_ctx client_ctx; /* key exchange context */
 uint8_t sk[32];            /* 32 random bytes long-term secret key */
-uint8_t their_pk[32];      /* the server's public key 
+uint8_t their_pk[32];      /* the server's public key
                             * (known ahead of time) */
 uint8_t seed[32];          /* 32 random bytes */
 uint8_t buf[48];           /* buffer for the key exchange messages */

--- a/doc/man/man3/crypto_memcmp.3monocypher
+++ b/doc/man/man3/crypto_memcmp.3monocypher
@@ -10,7 +10,7 @@
 .Ft int
 .Fo crypto_memcmp
 .Fa "const uint8_t *p1"
-.Fa"const uint8_t *p2"
+.Fa "const uint8_t *p2"
 .Fa "size_t n"
 .Fc
 .Ft int

--- a/doc/man/man3/crypto_sign.3monocypher
+++ b/doc/man/man3/crypto_sign.3monocypher
@@ -77,7 +77,7 @@ This recomputation doubles the execution time.
 checks that a given signature is genuine.
 Meaning, only someone who had the private key could have signed the
 message.
-.Sy \It does not run in constant time .
+.Sy \&It does not run in constant time .
 It does not have to in most threat models, because nothing is secret:
 everyone knows the public key, and the signature and message are
 rarely secret.


### PR DESCRIPTION
- There was some trailing whitespace on some of the lines of the new
  pages that I hadn't noticed.
- There was a .PP instead of .Pp.
- There was a .Fa with no space after it.

This is just a cleanup; no content has been changed.