### PR TITLE
Made Poly1305 10% faster

### DIFF
--- a/src/monocypher.c
+++ b/src/monocypher.c
@@ -24,6 +24,9 @@
 #define WIPE_BUFFER(buffer)  crypto_wipe(buffer, sizeof(buffer))
 #define MIN(a, b)            ((a) <= (b) ? (a) : (b))
 #define ALIGN(x, block_size) ((~(x) + 1) & ((block_size) - 1))
+#define LOAD32_LE_POLY1305(s)         *(u32*)(s)
+#define STORE32_LE_POLY1305(out,in)   *(u32*)(out) = in
+
 typedef int8_t   i8;
 typedef uint8_t  u8;
 typedef uint32_t u32;
@@ -371,9 +374,9 @@ void crypto_poly1305_init(crypto_poly1305_ctx *ctx, const u8 key[32])
     ctx->c[4] = 1;
     poly_clear_c(ctx);
     // load r and pad (r has some of its bits cleared)
-    FOR (i, 0, 1) { ctx->r  [0] = load32_le(key           ) & 0x0fffffff; }
-    FOR (i, 1, 4) { ctx->r  [i] = load32_le(key + i*4     ) & 0x0ffffffc; }
-    FOR (i, 0, 4) { ctx->pad[i] = load32_le(key + i*4 + 16);              }
+    FOR (i, 0, 1) { ctx->r  [0] = LOAD32_LE_POLY1305(key           ) & 0x0fffffff; }
+    FOR (i, 1, 4) { ctx->r  [i] = LOAD32_LE_POLY1305(key + i*4     ) & 0x0ffffffc; }
+    FOR (i, 0, 4) { ctx->pad[i] = LOAD32_LE_POLY1305(key + i*4 + 16);              }
 }
 
 void crypto_poly1305_update(crypto_poly1305_ctx *ctx,
@@ -388,10 +391,10 @@ void crypto_poly1305_update(crypto_poly1305_ctx *ctx,
     // Process the message block by block
     size_t nb_blocks = message_size >> 4;
     FOR (i, 0, nb_blocks) {
-        ctx->c[0] = load32_le(message +  0);
-        ctx->c[1] = load32_le(message +  4);
-        ctx->c[2] = load32_le(message +  8);
-        ctx->c[3] = load32_le(message + 12);
+        ctx->c[0] = LOAD32_LE_POLY1305(message +  0);
+        ctx->c[1] = LOAD32_LE_POLY1305(message +  4);
+        ctx->c[2] = LOAD32_LE_POLY1305(message +  8);
+        ctx->c[3] = LOAD32_LE_POLY1305(message + 12);
         poly_block(ctx);
         message += 16;
     }


### PR DESCRIPTION
Very simple change in the way the poly1305 functions handle 4-bytes to 32-bit integer conversions.
We de-reference the byte while casted as an unsigned integer and that automatically stores or loads the data as it should be. No need for any operations to be done on the data (shifting, ANDing, ORing, etc..)
The reason why I did not optimize the other load and store functions instead of just optimizing Poly1305 was because I used "make speed" and the only code that gets speed benefits is Poly1305, everything else is either the same or regresses.

Results using "make speed"
1490 MB/s --> 1632 MB/s (AMD Ryzen Threadripper 1920X 2x16GB ECC RAM, CPU 4.1GHz, MEM 3GHz)
1334 MB/s --> 1470 MB/s (AMD Ryzen 5 2500U 2x8GB RAM, CPU 2.2GHz Turbo 3.6GHz, MEM 2.4GHz)
1281 MB/s --> _1244 MB/s_ (Intel i7 4500U 2x4GB RAM, CPU 1.7GHz Turbo 3.0 GHz, MEM 2.133GHz)
1461 MB/s --> 1461 MB/s (iMac 5K Late 2015, i5 6600 3.3GHz Turbo 3.9GHz, 4x16GB RAM 1.866GHz)

It seems the change favours AMD's Zen architecture more than Intel's, I will investigate further once I have more hardware on hand, but you can test this yourself by cloning and using "make speed"

Here is code that compares the two ways of converting, and you can clearly see that my version only needs 3 "mov" operations while the older code needs about 30 when you use https://godbolt.org


[examplecode.c.zip](https://github.com/LoupVaillant/Monocypher/files/2994487/examplecode.c.zip)


 