### PR TITLE
Add HISTORY sections

### DIFF
--- a/doc/man/man3/crypto_argon2i.3monocypher
+++ b/doc/man/man3/crypto_argon2i.3monocypher
@@ -212,6 +212,15 @@ free(work_area);
 .Sh STANDARDS
 These functions implement Argon2i.
 An RFC draft is being maintained.
+.Sh HISTORY
+The
+.Fn crypto_argon2i_general
+function first appeared in Monocypher 0.1 but was called
+.Fn crypto_argon2i ;
+it was renamed to its current name in Monocypher 1.1.0.
+The current
+.Fn crypto_argon2i
+first appeared in Monocypher 1.1.0.
 .Sh CAVEATS
 Any deviation from the specified input and output length ranges results
 in

--- a/doc/man/man3/crypto_blake2b.3monocypher
+++ b/doc/man/man3/crypto_blake2b.3monocypher
@@ -208,6 +208,16 @@ crypto_blake2b_final(&ctx, hash);
 .Xr intro 3monocypher
 .Sh STANDARDS
 These functions implement BLAKE2b.
+.Sh HISTORY
+The
+.Fn crypto_blake2b ,
+.Fn crypto_blake2b_general ,
+.Fn crypto_blake2b_general_init ,
+.Fn crypto_blake2b_init ,
+.Fn crypto_blake2b_update ,
+and
+.Fn crypto_blake2b_final
+functions first appeared in Monocypher 0.1.
 .Sh CAVEATS
 Monocypher does not perform any input validation.
 Any deviation from the specified input and output length ranges results

--- a/doc/man/man3/crypto_chacha20_H.3monocypher
+++ b/doc/man/man3/crypto_chacha20_H.3monocypher
@@ -58,5 +58,9 @@ crypto_wipe(in , 16);
 This function implements HChacha20.
 HChacha20 derives from Chacha20 the same way HSalsa20 derives from
 Salsa20.
+.Sh HISTORY
+The
+.Fn crypto_chacha20_H
+function first appeared in Monocypher 0.1.
 .Sh CAVEATS
 .Sy This is not a general-purpose cryptographic hash function .

--- a/doc/man/man3/crypto_chacha20_encrypt.3monocypher
+++ b/doc/man/man3/crypto_chacha20_encrypt.3monocypher
@@ -282,6 +282,17 @@ Chacha20 is described in RFC 8439.
 XChacha20 derives from Chacha20 the same way XSalsa20 derives from
 Salsa20, and benefits from the same security reduction (proven secure
 as long as Chacha20 itself is secure).
+.Sh HISTORY
+The
+.Fn crypto_chacha20_encrypt ,
+.Fn crypto_chacha20_init ,
+functions first appeared in Monocypher 0.1.
+.Fn crypto_chacha20_stream
+was added in Monocypher 0.2.
+.Fn crypto_chacha20_x_init
+and
+.Fn crypto_chacha20_set_ctr
+were added in Monocypher 1.0.
 .Sh SECURITY CONSIDERATIONS
 .Ss Encrypted does not mean secure
 Chacha20 only protects against eavesdropping, not forgeries.

--- a/doc/man/man3/crypto_kex_x_init_client.3monocypher
+++ b/doc/man/man3/crypto_kex_x_init_client.3monocypher
@@ -240,6 +240,14 @@ crypto_kex_1_2(&server_ctx, session_key, client_pk, buf);
 .Sh STANDARDS
 These functions are equivalent to an implementation of the X pattern
 of the Noise protocol framework.
+.Sh HISTORY
+The
+.Fn crypto_kex_x_init_client ,
+.Fn crypto_kex_x_init_server ,
+.Fn crypto_kex_x_1 ,
+and
+.Fn crypto_kex_x_2
+functions first appeared in Monocypher 2.1.0.
 .Sh SECURITY CONSIDERATIONS
 Unlike the
 .Xr crypto_kex_xk1_init_client 3monocypher

--- a/doc/man/man3/crypto_kex_xk1_init_client.3monocypher
+++ b/doc/man/man3/crypto_kex_xk1_init_client.3monocypher
@@ -301,3 +301,13 @@ if (crypto_kex_xk1_4(&server_ctx, session_key, client_pk, buf) != 0)
 .Sh STANDARDS
 These functions are equivalent to an implementation of the XK1 pattern
 of the Noise protocol framework.
+.Sh HISTORY
+The
+.Fn crypto_kex_xk1_init_client ,
+.Fn crypto_kex_xk1_init_server ,
+.Fn crypto_kex_xk1_1 ,
+.Fn crypto_kex_xk1_2 ,
+.Fn crypto_kex_xk1_3 ,
+and
+.Fn crypto_kex_xk1_4
+functions first appeared in Monocypher 2.1.0.

--- a/doc/man/man3/crypto_key_exchange.3monocypher
+++ b/doc/man/man3/crypto_key_exchange.3monocypher
@@ -105,6 +105,13 @@ crypto_wipe(your_sk, 32);
 These functions implement X25519, described in RFC 7748.
 .Fn crypto_key_exchange
 uses HChacha20 as well.
+.Sh HISTORY
+The
+.Fn crypto_key_exchange
+function first appeared in Monocypher 0.2.
+The
+.Fn crypto_key_exchange_public_key
+macro alias first appeared in Monocypher 1.1.0.
 .Sh SECURITY CONSIDERATIONS
 If either of the long term secret keys leaks, it may compromise
 .Em all past messages .

--- a/doc/man/man3/crypto_lock.3monocypher
+++ b/doc/man/man3/crypto_lock.3monocypher
@@ -249,3 +249,13 @@ These functions implement RFC 8439, with XChacha20 instead of Chacha20.
 XChacha20 derives from Chacha20 the same way XSalsa20 derives from
 Salsa20, and benefits from the same security reduction (proven secure
 as long as Chacha20 itself is secure).
+.Sh HISTORY
+The
+.Fn crypto_lock
+and
+.Fn crypto_unlock
+functions first appeared in Monocypher 0.1.
+.Fn crypto_lock_aead
+and
+.Fn crypto_unlock_aead
+were introduced in Monocypher 1.1.0.

--- a/doc/man/man3/crypto_lock.3monocypher
+++ b/doc/man/man3/crypto_lock.3monocypher
@@ -259,3 +259,12 @@ functions first appeared in Monocypher 0.1.
 and
 .Fn crypto_unlock_aead
 were introduced in Monocypher 1.1.0.
+In Monocypher 2.0.0, the underlying algorithms for these functions were
+changed from a custom XChacha20/Poly1305 construction to an
+implementation of RFC 7539 (now RFC 8439) with XChacha20 instead of
+Chacha20.
+The
+.Fn crypto_lock_encrypt
+and
+.Fn crypto_lock_auth
+functions were removed in Monocypher 2.0.0.

--- a/doc/man/man3/crypto_lock_init.3monocypher
+++ b/doc/man/man3/crypto_lock_init.3monocypher
@@ -273,6 +273,20 @@ These functions implement RFC 8439, with XChacha20 instead of Chacha20.
 XChacha20 derives from Chacha20 the same way XSalsa20 derives from
 Salsa20, and benefits from the same security reduction (proven secure
 as long as Chacha20 itself is secure).
+.Sh HISTORY
+The
+.Fn crypto_lock_init ,
+.Fn crypto_lock_auth_ad ,
+.Fn crypto_lock_auth_message ,
+.Fn crypto_lock_update ,
+.Fn crypto_lock_final ,
+.Fn crypto_unlock_init ,
+.Fn crypto_unlock_auth_ad ,
+.Fn crypto_unlock_auth_message ,
+.Fn crypto_unlock_update ,
+and
+.Fn crypto_unlock_final
+functions first appeared in Monocypher 1.1.0.
 .Sh SECURITY CONSIDERATIONS
 Messages are not verified until the call to
 .Fn crypto_unlock_final .

--- a/doc/man/man3/crypto_lock_init.3monocypher
+++ b/doc/man/man3/crypto_lock_init.3monocypher
@@ -287,6 +287,14 @@ The
 and
 .Fn crypto_unlock_final
 functions first appeared in Monocypher 1.1.0.
+.Fn crypto_lock_aead_auth
+and
+.Fn crypto_unlock_aead_auth
+were renamed to
+.Fn crypto_lock_auth_ad
+and
+.Fn crypto_unlock_auth_ad
+respectively in Monocypher 2.0.0.
 .Sh SECURITY CONSIDERATIONS
 Messages are not verified until the call to
 .Fn crypto_unlock_final .

--- a/doc/man/man3/crypto_memcmp.3monocypher
+++ b/doc/man/man3/crypto_memcmp.3monocypher
@@ -36,3 +36,10 @@ instead.
 .Sh SEE ALSO
 .Xr crypto_verify16 3monocypher ,
 .Xr intro 3monocypher
+.Sh HISTORY
+The
+.Fn crypto_memcmp
+function first appeared in Monocypher 0.1.
+.Fn crypto_zerocmp
+was introduced in Monocypher 0.6.
+These functions were removed in Monocypher 1.1.0.

--- a/doc/man/man3/crypto_poly1305.3monocypher
+++ b/doc/man/man3/crypto_poly1305.3monocypher
@@ -135,6 +135,15 @@ crypto_poly1305_final(&ctx, mac);
 .Xr intro 3monocypher
 .Sh STANDARDS
 These functions implement Poly1305, described in RFC 8439.
+.Sh HISTORY
+The
+.Fn crypto_poly1305_init ,
+.Fn crypto_poly1305_update ,
+and
+.Fn crypto_poly1305_final
+functions first appeared in Monocypher 0.1.
+.Fn crypto_poly1305
+first appeared in Monocypher 1.1.0.
 .Sh SECURITY CONSIDERATIONS
 Poly1305 is difficult to use correctly.
 Do not use it unless you are absolutely sure what you are doing.

--- a/doc/man/man3/crypto_sign.3monocypher
+++ b/doc/man/man3/crypto_sign.3monocypher
@@ -138,6 +138,13 @@ if (crypto_check(signature, pk, message, 500)) {
 These functions implement PureEdDSA with Curve25519 and Blake2b, as
 described in RFC 8032.
 This is the same as Ed25519, with Blake2b instead of SHA-512.
+.Sh HISTORY
+The
+.Fn crypto_sign ,
+.Fn crypto_check ,
+and
+.Fn crypto_sign_public_key
+functions appeared in Monocypher 0.2.
 .Sh SECURITY CONSIDERATIONS
 .Ss Signature malleability
 EdDSA signatures are not unique like cryptographic hashes.

--- a/doc/man/man3/crypto_sign.3monocypher
+++ b/doc/man/man3/crypto_sign.3monocypher
@@ -145,6 +145,11 @@ The
 and
 .Fn crypto_sign_public_key
 functions appeared in Monocypher 0.2.
+.Pp
+.Sy A critical security vulnerability
+that caused all-zero signatures to be accepted was introduced in
+Monocypher 0.3;
+it was fixed in Monocypher 1.1.1 and 2.0.4.
 .Sh SECURITY CONSIDERATIONS
 .Ss Signature malleability
 EdDSA signatures are not unique like cryptographic hashes.

--- a/doc/man/man3/crypto_sign_init_first_pass.3monocypher
+++ b/doc/man/man3/crypto_sign_init_first_pass.3monocypher
@@ -175,6 +175,11 @@ The
 and
 .Fn crypto_check_final
 functions first appeared in Monocypher 1.1.0.
+.Pp
+.Sy A critical security vulnerability
+that caused all-zero signatures to be accepted was introduced in
+Monocypher 0.3;
+it was fixed in Monocypher 1.1.1 and 2.0.4.
 .Sh SECURITY CONSIDERATIONS
 Messages are not verified until the call to
 .Fn crypto_check_final .

--- a/doc/man/man3/crypto_sign_init_first_pass.3monocypher
+++ b/doc/man/man3/crypto_sign_init_first_pass.3monocypher
@@ -164,6 +164,17 @@ if (crypto_check_final(&ctx)) {
 These functions implement PureEdDSA with Curve25519 and Blake2b, as
 described in RFC 8032.
 This is the same as Ed25519, with Blake2b instead of SHA-512.
+.Sh HISTORY
+The
+.Fn crypto_sign_init_first_pass ,
+.Fn crypto_sign_update ,
+.Fn crypto_sign_final ,
+.Fn crypto_sign_init_second_pass ,
+.Fn crypto_check_init ,
+.Fn crypto_check_update ,
+and
+.Fn crypto_check_final
+functions first appeared in Monocypher 1.1.0.
 .Sh SECURITY CONSIDERATIONS
 Messages are not verified until the call to
 .Fn crypto_check_final .

--- a/doc/man/man3/crypto_verify16.3monocypher
+++ b/doc/man/man3/crypto_verify16.3monocypher
@@ -61,3 +61,14 @@ These functions return 0 if the two memory chunks are the same, -1
 otherwise.
 .Sh SEE ALSO
 .Xr intro 3monocypher
+.Sh HISTORY
+The
+.Fn crypto_verify16 ,
+.Fn crypto_verify32 ,
+.Fn crypto_verify64
+functions first appeared in Monocypher 1.1.0.
+They replaced the
+.Fn crypto_memcmp
+and
+.Fn crypto_zerocmp
+functions that were present until Monocypher 1.0.1.

--- a/doc/man/man3/crypto_wipe.3monocypher
+++ b/doc/man/man3/crypto_wipe.3monocypher
@@ -52,3 +52,7 @@ for instructions on how to lock down memory on common operating systems.
 This function returns nothing.
 .Sh SEE ALSO
 .Xr intro 3monocypher
+.Sh HISTORY
+The
+.Fn crypto_wipe
+function first appeared in Monocypher 1.1.0.

--- a/doc/man/man3/crypto_x25519.3monocypher
+++ b/doc/man/man3/crypto_x25519.3monocypher
@@ -101,6 +101,12 @@ crypto_wipe(shared_secret, 32);
 .Xr intro 3monocypher
 .Sh STANDARDS
 This function implements X25519, described in RFC 7748.
+.Sh HISTORY
+The
+.Fn crypto_x25519 ,
+and
+.Fn crypto_x25519_public_key
+functions first appeared in Monocypher 0.1.
 .Sh SECURITY CONSIDERATIONS
 If either of the long term secret keys leaks, it may compromise
 .Em all past messages .


### PR DESCRIPTION
These changes make it easier for people who read a newer manual than the one they have. This could happen if a long-term stability Linux distribution ends up packaging Monocypher and backporting security fixes, but developers are reading the manual on the web.

The wording of each first sentence matches OpenBSD's for section 3 HISTORY sections.