### PR TITLE
manual: roff formatting fixes

### DIFF
--- a/doc/man/man3/crypto_kex_x_init_client.3monocypher
+++ b/doc/man/man3/crypto_kex_x_init_client.3monocypher
@@ -111,7 +111,6 @@ It must thus be known to the client before making a connection.
 A 80-byte message, which is generated and sent by the client.
 It is the only message in the key exchange.
 .El
-.Pp
 .Ss Key exchange as the client
 When starting a new connection to the server, the client first reads
 the server's public key from the network; then it calls

--- a/doc/man/man3/crypto_poly1305.3monocypher
+++ b/doc/man/man3/crypto_poly1305.3monocypher
@@ -34,7 +34,8 @@
 .Fc
 .Sh DESCRIPTION
 Poly1305 is a one-time message authentication code.
-"One-time" means the authentication key can be used only once.
+.Dq One-time
+means the authentication key can be used only once.
 .Sy This makes Poly1305 easy to misuse .
 On the other hand, Poly1305 is fast, and provably secure if used
 correctly.

--- a/doc/man/man3/intro.3monocypher
+++ b/doc/man/man3/intro.3monocypher
@@ -170,7 +170,8 @@ hard to use correctly and securely.
 Reads may be interrupted, and more attacks are possible on a file than
 on a system call.
 .Ss Timing attacks
-Monocypher runs in "constant time".
+Monocypher runs in
+.Dq constant time .
 There is no flow from secrets to timings.
 No secret dependent indices, no secret dependent branches.
 Nevertheless, there are a couple important caveats.
@@ -198,7 +199,8 @@ If an attacker can add data to the input before it is compressed and
 encrypted, they can observe changes to the ciphertext length to recover
 secrets from the input.
 Researchers have demonstrated an attack on HTTPS to steal session
-cookies when compression is enabled, dubbed "CRIME".
+cookies when compression is enabled, dubbed
+.Dq CRIME .
 .Ss Forward secrecy
 Long term secrets cannot be expected to stay safe indefinitely.
 Users may reveal them by mistake, or the host computer might have a


### PR DESCRIPTION
- remove dead `.Pp` before `.Ss`
- use `.Dq` for quotes ("" doesn't get rendered with typographically correct quotes where possible)