### PR TITLE
README: nitpicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ platform, you can change them like this:
 
     $ make CC="clang -std=c99" CFLAGS="-O2"
 
-### Option 3 install it on your system
+### Option 3: install it on your system
 
 The following should work on most UNIX systems:
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ settings.  To run the code under the TIS interpreter, run
 (Note: `tis-interpreter.sh` is part of TIS.  If it is not in your
 path, adjust the command accordingly.)
 
-[Frama-c]:http://frama-c.com/
-[TIS]: http://trust-in-soft.com/tis-interpreter/
+[Frama-c]:https://frama-c.com/
+[TIS]: https://trust-in-soft.com/tis-interpreter/
 
 
 Speed benchmark


### PR DESCRIPTION
Options 1 and 2 had colons after them, but option 3 didn't.