### PR TITLE
Clean up kex documentation removal

### DIFF
--- a/doc/man/man3/crypto_key_exchange.3monocypher
+++ b/doc/man/man3/crypto_key_exchange.3monocypher
@@ -24,12 +24,6 @@ computes a shared key with your secret key and their public key.
 .Pp
 .Fn crypto_key_exchange_public_key
 deterministically computes the public key from a random secret key.
-It is a medium-level primitive.
-Prefer the
-.Xr crypto_kex_xk1_init_client 3monocypher
-and
-.Xr crypto_kex_x_init_client 3monocypher
-families of functions unless you have a specific reason not to.
 .Pp
 The arguments are:
 .Bl -tag -width Ds

--- a/doc/man/man3/crypto_x25519.3monocypher
+++ b/doc/man/man3/crypto_x25519.3monocypher
@@ -112,12 +112,6 @@ If either of the long term secret keys leaks, it may compromise
 .Em all past messages .
 This can be avoided by using protocols that provide forward secrecy,
 such as the X3DH key agreement protocol.
-Monocypher provides the
-.Xr crypto_kex_xk1_init_client 3monocypher
-and
-.Xr crypto_kex_x_init_client 3monocypher
-families of functions,
-which provide forward secrecy.
 .Sh IMPLEMENTATION DETAILS
 The most significant bit of the public key is systematically ignored.
 It is not needed because every public key should be smaller than

--- a/doc/man/man3/intro.3monocypher
+++ b/doc/man/man3/intro.3monocypher
@@ -34,17 +34,8 @@ implements the Argon2i resource intensive hash algorithm.
 Argon2 won the password hashing competition in 2015.
 Unlike Scrypt, Argon2i is immune to timing attacks.
 .Ss Key exchange
-The
-.Xr crypto_kex_xk1_init_client 3monocypher
-and
-.Xr crypto_kex_x_init_client 3monocypher
-families of functions,
-provide key exhange protocols with forward secrecy.
-.Pp
-If more control over the key exchange is required,
-there is
-.Xr crypto_key_exchange 3monocypher ,
-which implements X25519, an elliptic curve Diffie Hellman key exchange
+.Xr crypto_key_exchange 3monocypher
+implements X25519, an elliptic curve Diffie Hellman key exchange
 algorithm based on Curve25519.
 X25519 derives a shared secret from two private/public key pairs.
 It is fast, simple, and relatively easy to implement securely.


### PR DESCRIPTION
Related to git commit 6163d8195a3acf2e143d20843a602fd5fb7671d5.

It doesn't seem reasonable to ship a manual referencing functions that don't exist.