### PR TITLE
Change release.sh to use find -exec

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -23,10 +23,7 @@ rm -rf $FOLDER
 rsync -ad --exclude-from=tarball_ignore ./ $FOLDER
 
 # Replace version markers by the actual version number (from tags)
-for file in `find monocypher-$VERSION -type f`
-do
-    sed -i "s/__git__/$VERSION/g" $file
-done
+find $FOLDER -type f -exec sed -i "s/__git__/$VERSION/g" \{\} \;
 
 # Remove the dist target from the makefile (no recursive releases!),
 # and the tests/vector.h target, which ships with the tarball.


### PR DESCRIPTION
This avoids some potential weirdness with whitespace in find and for.

Probably not going to be an actual concern, but it's just a nice general improvement.