### PR TITLE
Added PlatformIO file to make it easier to depend on monocrypt

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,15 @@
+{
+    "name": "Monocypher",
+    "description": "An easy to use, easy to deploy crypto library. It provides functions for authenticated encryption, hashing, password key derivation, key exchange, and public key signatures.",
+    "keywords":  "encryption,signing,key-exchange,password-key-derivation",
+    "version": "2.0.8",
+    "repository": "https://github.com/LoupVaillant/Monocypher",
+    "build": {
+        "srcDir": "src/",
+        "includeDir": "src/",
+        "flags": [
+            "-DBLAKE2_NO_UNROLLING"
+        ],
+        "libLDFMode": "off"
+    }
+}


### PR DESCRIPTION
For a nice IoT project I'm working on, I'm going with Monocypher, is has just the right stuff in there.

A lot of people are now using PlatformIO to help with dependency management and compilation for all kinds of boards. The only other cryptography library on there is ArduinoCrypto, it is limited to arduino, quite big, slowish, and doesn't contain the opinionated api that Monocypher and friends adhere to. I think it would be a great portable addition, and PlatformIO could give some users for Monocypher.

The PlatformIO scanner takes care of it all (after initial submission), and only when you bump the version in the version field, will it look for the tag in the repo to find which sourcecode corresponds to that specific version.

I've tested the below config, and used the `BLAKE2_NO_UNROLLING` since platform IO is mostly on limited platforms. Although that might be to restricting of a choice.