### PR TITLE
Remove unnecessary dependency on 2's complement

### DIFF
--- a/src/monocypher.c
+++ b/src/monocypher.c
@@ -1029,7 +1029,7 @@ static void fe_sub (fe h,const fe f,const fe g){FOR(i,0,10) h[i] = f[i] - g[i];}
 
 static void fe_cswap(fe f, fe g, int b)
 {
-    i32 mask = -b; // rely on 2's complement: -1 = 0xffffffff
+    u32 mask = -b; // -1 = 0xffffffff
     FOR (i, 0, 10) {
         i32 x = (f[i] ^ g[i]) & mask;
         f[i] = f[i] ^ x;
@@ -1039,7 +1039,7 @@ static void fe_cswap(fe f, fe g, int b)
 
 static void fe_ccopy(fe f, const fe g, int b)
 {
-    i32 mask = -b; // rely on 2's complement: -1 = 0xffffffff
+    u32 mask = -b; // -1 = 0xffffffff
     FOR (i, 0, 10) {
         i32 x = (f[i] ^ g[i]) & mask;
         f[i] = f[i] ^ x;


### PR DESCRIPTION
Just a minor thing I noticed. 2's complement will be the only signed integer representation in C2X (http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2412.pdf), but since Monocypher targets C99, I think it would be good to avoid relying on it.