### PR TITLE
Fix makefile rule when test/vectors.h is missing

### DIFF
--- a/makefile
+++ b/makefile
@@ -186,7 +186,7 @@ tests/vectors.h:
 	@echo " need libsodium."
 	@echo "======================================================"
 	@echo ""
-	return 1
+	exit 1
 
 dist: tests/vectors.h
 	./release.sh


### PR DESCRIPTION
`return` only works in functions, so when I run `make check` with no
tests/vectors.h, I get

	return 1
	make: return: Command not found
	make: *** [makefile:189: tests/vectors.h] Error 127

While I guess this does the job, the right thing to do here is `exit 1`.