### PR TITLE
Add SONAME to shared library

### DIFF
--- a/makefile
+++ b/makefile
@@ -95,7 +95,7 @@ lib/libmonocypher.so: lib/libmonocypher.so.2
 	ln -sf `basename $<` $@
 lib/libmonocypher.so.2: lib/monocypher.o $(LINK_SHA512)
 	@mkdir -p $(@D)
-	$(CC) $(CFLAGS) -shared -o $@ $^
+	$(CC) $(CFLAGS) -shared -Wl,-soname,libmonocypher.so.2 -o $@ $^
 lib/sha512.o    : src/optional/sha512.c src/optional/sha512.h
 lib/monocypher.o: src/monocypher.c src/monocypher.h
 lib/monocypher.o lib/sha512.o:


### PR DESCRIPTION
This is my oversight and probably should've been done ages ago. The makefile never *actually* added the SONAME information into the shared library.

`$ objdump -p lib/libmonocypher.so` actually contains a `SONAME` after recompiling with this patch applied.