### PR TITLE
Use stdint.h over inttypes.h

### DIFF
--- a/src/monocypher.h
+++ b/src/monocypher.h
@@ -3,8 +3,8 @@
 #ifndef MONOCYPHER_H
 #define MONOCYPHER_H
 
-#include <inttypes.h>
 #include <stddef.h>
+#include <stdint.h>
 
 ////////////////////////
 /// Type definitions ///


### PR DESCRIPTION
Monocypher uses nothing from `inttypes.h`, other than `stdint.h` that `inttypes.h` indirectly includes.

This seems to make `clang --target=wasm32` more amenable to Monocypher in a freestanding environment.