### PR TITLE
Revert "intro: format link with .Lk"

### DIFF
--- a/doc/man/man3/intro.3monocypher
+++ b/doc/man/man3/intro.3monocypher
@@ -161,8 +161,7 @@ Cryptographic libraries are easy to misuse.
 Even Monocypher allows a number of fatal mistakes.
 .Pp
 Users should follow a formal introduction to cryptography.
-We currently recommend the
-.Lk https://www.crypto101.io/ "Crypto 101 online course" .
+We currently recommend the https://www.crypto101.io/ online course.
 .Ss Random number generation
 Use the facilities of your operating system.
 Avoid user space random number generators.


### PR DESCRIPTION
This reverts commit df321b37cda1db5e8bd6fa76e4daf01ac087b865.

As it turns out,
groff (1.22.4) will spew complaints about the Lk formatting to stderr,
even though it's rendered perfectly fine.