### PR TITLE
Add a script to extract examples from man pages

### DIFF
--- a/doc/man/man3/test_examples.lua
+++ b/doc/man/man3/test_examples.lua
@@ -1,0 +1,42 @@
+#! /usr/bin/env lua
+
+local lfs = require( "lfs" )
+
+local all = {
+	"#include \"../../../src/monocypher.h\"",
+	"#include \"../../../src/optional/monocypher-ed25519.h\"",
+	"#include <stdlib.h>",
+	"int main() {",
+}
+
+local function AddExamples( man )
+	for code in man:gmatch( "%.Bd[^\n]*\n(.-)%.Ed" ) do
+		table.insert( all, "{" )
+		table.insert( all, code )
+		table.insert( all, "}" )
+	end
+end
+
+local function AddDir( path )
+	for file in lfs.dir( path ) do
+		local attr = lfs.symlinkattributes( path .. "/" .. file )
+		if file:match( "%.3monocypher$" ) and attr.mode == "file" then
+			table.insert( all, "// " .. path .. "/" .. file )
+
+			local f = assert( io.open( path .. "/" .. file, "r" ) )
+			local contents = assert( f:read( "*all" ) )
+			f:close()
+
+			AddExamples( contents )
+
+			table.insert( all, "" )
+		end
+	end
+end
+
+AddDir( "." )
+AddDir( "optional" )
+
+table.insert( all, "}" )
+
+print( table.concat( all, "\n" ) )


### PR DESCRIPTION
I remember doing this by hand last time to make sure all the examples compiled and lots of them have broken since then, so maybe it makes sense to automate it

(with -Wno-discard-qualifiers)

```
asdf.c: In function ‘main’:
asdf.c:11:1: warning: implicit declaration of function ‘crypto_xchacha20_encrypt’; did you mean ‘crypto_xchacha20_ctr’? [-Wimplicit-function-declaration]
   11 | crypto_xchacha20_encrypt(cipher_text, plain_text, 500, key, nonce);
      | ^~~~~~~~~~~~~~~~~~~~~~~~
      | crypto_xchacha20_ctr
asdf.c:36:33: error: ‘ctx’ undeclared (first use in this function); did you mean ‘ctr’?
   36 |     ctr = crypto_xchacha20_ctr(&ctx, cipher_text+i, plain_text+i,
      |                                 ^~~
      |                                 ctr
asdf.c:36:33: note: each undeclared identifier is reported only once for each function it appears in
asdf.c:36:63: warning: passing argument 3 of ‘crypto_xchacha20_ctr’ makes integer from pointer without a cast [-Wint-conversion]
   36 |     ctr = crypto_xchacha20_ctr(&ctx, cipher_text+i, plain_text+i,
      |                                                     ~~~~~~~~~~^~
      |                                                               |
      |                                                               const uint8_t * {aka const unsigned char *}
In file included from asdf.c:1:
../../../src/monocypher.h:292:46: note: expected ‘size_t’ {aka ‘long unsigned int’} but argument is of type ‘const uint8_t *’ {aka ‘const unsigned char *’}
  292 |                               size_t         text_size,
      |                               ~~~~~~~~~~~~~~~^~~~~~~~~
asdf.c:37:32: warning: passing argument 4 of ‘crypto_xchacha20_ctr’ makes pointer from integer without a cast [-Wint-conversion]
   37 |                                64, ctr);
      |                                ^~
      |                                |
      |                                int
In file included from asdf.c:1:
../../../src/monocypher.h:293:46: note: expected ‘const uint8_t *’ {aka ‘const unsigned char *’} but argument is of type ‘int’
  293 |                               const uint8_t  key[32],
      |                               ~~~~~~~~~~~~~~~^~~~~~~
asdf.c:37:36: warning: passing argument 5 of ‘crypto_xchacha20_ctr’ makes pointer from integer without a cast [-Wint-conversion]
   37 |                                64, ctr);
      |                                    ^~~
      |                                    |
      |                                    uint64_t {aka long unsigned int}
In file included from asdf.c:1:
../../../src/monocypher.h:294:46: note: expected ‘const uint8_t *’ {aka ‘const unsigned char *’} but argument is of type ‘uint64_t’ {aka ‘long unsigned int’}
  294 |                               const uint8_t  nonce[24],
      |                               ~~~~~~~~~~~~~~~^~~~~~~~~
asdf.c:36:11: error: too few arguments to function ‘crypto_xchacha20_ctr’
   36 |     ctr = crypto_xchacha20_ctr(&ctx, cipher_text+i, plain_text+i,
      |           ^~~~~~~~~~~~~~~~~~~~
In file included from asdf.c:1:
../../../src/monocypher.h:290:10: note: declared here
  290 | uint64_t crypto_xchacha20_ctr(uint8_t       *cipher_text,
      |          ^~~~~~~~~~~~~~~~~~~~
asdf.c:41:39: error: ‘i’ undeclared (first use in this function)
   41 |                      cipher_text+500-(i-64),
      |                                       ^
asdf.c:43:34: warning: passing argument 5 of ‘crypto_xchacha20_ctr’ makes pointer from integer without a cast [-Wint-conversion]
   43 |                      500-(i-64), ctr);
      |                                  ^~~
      |                                  |
      |                                  uint64_t {aka long unsigned int}
In file included from asdf.c:1:
../../../src/monocypher.h:294:46: note: expected ‘const uint8_t *’ {aka ‘const unsigned char *’} but argument is of type ‘uint64_t’ {aka ‘long unsigned int’}
  294 |                               const uint8_t  nonce[24],
      |                               ~~~~~~~~~~~~~~~^~~~~~~~~
asdf.c:40:1: error: too few arguments to function ‘crypto_xchacha20_ctr’
   40 | crypto_xchacha20_ctr(&ctx,
      | ^~~~~~~~~~~~~~~~~~~~
In file included from asdf.c:1:
../../../src/monocypher.h:290:10: note: declared here
  290 | uint64_t crypto_xchacha20_ctr(uint8_t       *cipher_text,
      |          ^~~~~~~~~~~~~~~~~~~~
asdf.c:57:29: warning: passing argument 3 of ‘crypto_chacha20’ makes integer from pointer without a cast [-Wint-conversion]
   57 |                 plain_text  + (3 * 64),
      |                 ~~~~~~~~~~~~^~~~~~~~~~
      |                             |
      |                             const uint8_t * {aka const unsigned char *}
In file included from asdf.c:1:
../../../src/monocypher.h:271:37: note: expected ‘size_t’ {aka ‘long unsigned int’} but argument is of type ‘const uint8_t *’ {aka ‘const unsigned char *’}
  271 |                      size_t         text_size,
      |                      ~~~~~~~~~~~~~~~^~~~~~~~~
asdf.c:58:17: warning: passing argument 4 of ‘crypto_chacha20’ makes pointer from integer without a cast [-Wint-conversion]
   58 |                 500         - (3 * 64),
      |                 ^~~~~~~~~~~~~~~~~~~~~~
      |                 |
      |                 int
In file included from asdf.c:1:
../../../src/monocypher.h:272:37: note: expected ‘const uint8_t *’ {aka ‘const unsigned char *’} but argument is of type ‘int’
  272 |                      const uint8_t  key[32],
      |                      ~~~~~~~~~~~~~~~^~~~~~~
asdf.c:55:1: error: too many arguments to function ‘crypto_chacha20’
   55 | crypto_chacha20(&ctx,
      | ^~~~~~~~~~~~~~~
In file included from asdf.c:1:
../../../src/monocypher.h:269:6: note: declared here
  269 | void crypto_chacha20(uint8_t       *cipher_text,
      |      ^~~~~~~~~~~~~~~
asdf.c:61:36: warning: passing argument 3 of ‘crypto_chacha20’ makes integer from pointer without a cast [-Wint-conversion]
   61 | crypto_chacha20(&ctx, cipher_text, plain_text, 3 * 64,
      |                                    ^~~~~~~~~~
      |                                    |
      |                                    const uint8_t * {aka const unsigned char *}
In file included from asdf.c:1:
../../../src/monocypher.h:271:37: note: expected ‘size_t’ {aka ‘long unsigned int’} but argument is of type ‘const uint8_t *’ {aka ‘const unsigned char *’}
  271 |                      size_t         text_size,
      |                      ~~~~~~~~~~~~~~~^~~~~~~~~
asdf.c:61:48: warning: passing argument 4 of ‘crypto_chacha20’ makes pointer from integer without a cast [-Wint-conversion]
   61 | crypto_chacha20(&ctx, cipher_text, plain_text, 3 * 64,
      |                                                ^~~~~~
      |                                                |
      |                                                int
In file included from asdf.c:1:
../../../src/monocypher.h:272:37: note: expected ‘const uint8_t *’ {aka ‘const unsigned char *’} but argument is of type ‘int’
  272 |                      const uint8_t  key[32],
      |                      ~~~~~~~~~~~~~~~^~~~~~~
asdf.c:61:1: error: too many arguments to function ‘crypto_chacha20’
   61 | crypto_chacha20(&ctx, cipher_text, plain_text, 3 * 64,
      | ^~~~~~~~~~~~~~~
In file included from asdf.c:1:
../../../src/monocypher.h:269:6: note: declared here
  269 | void crypto_chacha20(uint8_t       *cipher_text,
      |      ^~~~~~~~~~~~~~~
asdf.c:170:29: warning: passing argument 1 of ‘crypto_sign_init_first_pass’ from incompatible pointer type [-Wincompatible-pointer-types]
  170 | crypto_sign_init_first_pass(&ctx, sk, pk);
      |                             ^~~~
      |                             |
      |                             crypto_sign_ctx * {aka struct <anonymous> *}
In file included from asdf.c:1:
../../../src/monocypher.h:225:60: note: expected ‘crypto_sign_ctx_abstract *’ {aka ‘struct <anonymous> *’} but argument is of type ‘crypto_sign_ctx *’ {aka ‘struct <anonymous> *’}
  225 | void crypto_sign_init_first_pass(crypto_sign_ctx_abstract *ctx,
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
asdf.c:174:24: warning: passing argument 1 of ‘crypto_sign_update’ from incompatible pointer type [-Wincompatible-pointer-types]
  174 |     crypto_sign_update(&ctx, message + i, 100);
      |                        ^~~~
      |                        |
      |                        crypto_sign_ctx * {aka struct <anonymous> *}
In file included from asdf.c:1:
../../../src/monocypher.h:228:51: note: expected ‘crypto_sign_ctx_abstract *’ {aka ‘struct <anonymous> *’} but argument is of type ‘crypto_sign_ctx *’ {aka ‘struct <anonymous> *’}
  228 | void crypto_sign_update(crypto_sign_ctx_abstract *ctx,
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
asdf.c:176:30: warning: passing argument 1 of ‘crypto_sign_init_second_pass’ from incompatible pointer type [-Wincompatible-pointer-types]
  176 | crypto_sign_init_second_pass(&ctx);
      |                              ^~~~
      |                              |
      |                              crypto_sign_ctx * {aka struct <anonymous> *}
In file included from asdf.c:1:
../../../src/monocypher.h:230:61: note: expected ‘crypto_sign_ctx_abstract *’ {aka ‘struct <anonymous> *’} but argument is of type ‘crypto_sign_ctx *’ {aka ‘struct <anonymous> *’}
  230 | void crypto_sign_init_second_pass(crypto_sign_ctx_abstract *ctx);
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
asdf.c:178:24: warning: passing argument 1 of ‘crypto_sign_update’ from incompatible pointer type [-Wincompatible-pointer-types]
  178 |     crypto_sign_update(&ctx, message + i, 100);
      |                        ^~~~
      |                        |
      |                        crypto_sign_ctx * {aka struct <anonymous> *}
In file included from asdf.c:1:
../../../src/monocypher.h:228:51: note: expected ‘crypto_sign_ctx_abstract *’ {aka ‘struct <anonymous> *’} but argument is of type ‘crypto_sign_ctx *’ {aka ‘struct <anonymous> *’}
  228 | void crypto_sign_update(crypto_sign_ctx_abstract *ctx,
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
asdf.c:180:19: warning: passing argument 1 of ‘crypto_sign_final’ from incompatible pointer type [-Wincompatible-pointer-types]
  180 | crypto_sign_final(&ctx, signature);
      |                   ^~~~
      |                   |
      |                   crypto_sign_ctx * {aka struct <anonymous> *}
In file included from asdf.c:1:
../../../src/monocypher.h:232:50: note: expected ‘crypto_sign_ctx_abstract *’ {aka ‘struct <anonymous> *’} but argument is of type ‘crypto_sign_ctx *’ {aka ‘struct <anonymous> *’}
  232 | void crypto_sign_final(crypto_sign_ctx_abstract *ctx, uint8_t signature[64]);
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
asdf.c:188:19: warning: passing argument 1 of ‘crypto_check_init’ from incompatible pointer type [-Wincompatible-pointer-types]
  188 | crypto_check_init(&ctx, signature, pk);
      |                   ^~~~
      |                   |
      |                   crypto_check_ctx * {aka struct <anonymous> *}
In file included from asdf.c:1:
../../../src/monocypher.h:235:53: note: expected ‘crypto_check_ctx_abstract *’ {aka ‘struct <anonymous> *’} but argument is of type ‘crypto_check_ctx *’ {aka ‘struct <anonymous> *’}
  235 | void crypto_check_init  (crypto_check_ctx_abstract *ctx,
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
asdf.c:190:25: warning: passing argument 1 of ‘crypto_check_update’ from incompatible pointer type [-Wincompatible-pointer-types]
  190 |     crypto_check_update(&ctx, message + i, 100);
      |                         ^~~~
      |                         |
      |                         crypto_check_ctx * {aka struct <anonymous> *}
In file included from asdf.c:1:
../../../src/monocypher.h:238:53: note: expected ‘crypto_check_ctx_abstract *’ {aka ‘struct <anonymous> *’} but argument is of type ‘crypto_check_ctx *’ {aka ‘struct <anonymous> *’}
  238 | void crypto_check_update(crypto_check_ctx_abstract *ctx,
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
asdf.c:192:24: warning: passing argument 1 of ‘crypto_check_final’ from incompatible pointer type [-Wincompatible-pointer-types]
  192 | if (crypto_check_final(&ctx)) {
      |                        ^~~~
      |                        |
      |                        crypto_check_ctx * {aka struct <anonymous> *}
In file included from asdf.c:1:
../../../src/monocypher.h:240:53: note: expected ‘crypto_check_ctx_abstract *’ {aka ‘struct <anonymous> *’} but argument is of type ‘crypto_check_ctx *’ {aka ‘struct <anonymous> *’}
  240 | int crypto_check_final  (crypto_check_ctx_abstract *ctx);
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
asdf.c:373:5: error: unknown type name ‘SHA2_CTX’
  373 |     SHA2_CTX hash_ctx;
      |     ^~~~~~~~
asdf.c:377:1: error: invalid storage class for function ‘my_hash’
  377 | my_hash(uint8_t hash[64], const uint8_t *msg, size_t len)
      | ^~~~~~~
asdf.c: In function ‘my_hash’:
asdf.c:379:5: error: unknown type name ‘SHA2_CTX’
  379 |     SHA2_CTX ctx;
      |     ^~~~~~~~
asdf.c:380:5: warning: implicit declaration of function ‘SHA512Init’ [-Wimplicit-function-declaration]
  380 |     SHA512Init(&ctx);
      |     ^~~~~~~~~~
asdf.c:381:5: warning: implicit declaration of function ‘SHA512Update’ [-Wimplicit-function-declaration]
  381 |     SHA512Update(&ctx, msg, len);
      |     ^~~~~~~~~~~~
asdf.c:382:5: warning: implicit declaration of function ‘SHA512Final’ [-Wimplicit-function-declaration]
  382 |     SHA512Final(hash, &ctx);
      |     ^~~~~~~~~~~
asdf.c: In function ‘main’:
asdf.c:386:1: error: invalid storage class for function ‘my_init’
  386 | my_init(void *ctx)
      | ^~~~~~~
asdf.c:393:1: error: invalid storage class for function ‘my_update’
  393 | my_update(void *ctx, const uint8_t *msg, size_t len)
      | ^~~~~~~~~
asdf.c:400:1: error: invalid storage class for function ‘my_final’
  400 | my_final(void *ctx, uint8_t *hash)
      | ^~~~~~~~
asdf.c:407:5: error: initializer element is not constant
  407 |     my_hash,
      |     ^~~~~~~
asdf.c:407:5: note: (near initialization for ‘my_vtable.hash’)
asdf.c:408:5: error: initializer element is not constant
  408 |     my_init,
      |     ^~~~~~~
asdf.c:408:5: note: (near initialization for ‘my_vtable.init’)
asdf.c:409:5: error: initializer element is not constant
  409 |     my_update,
      |     ^~~~~~~~~
asdf.c:409:5: note: (near initialization for ‘my_vtable.update’)
asdf.c:410:5: error: initializer element is not constant
  410 |     my_final,
      |     ^~~~~~~~
asdf.c:410:5: note: (near initialization for ‘my_vtable.final’)
asdf.c: In function ‘main’:
asdf.c:423:5: warning: implicit declaration of function ‘arc4random_buf’ [-Wimplicit-function-declaration]
  423 |     arc4random_buf(sk, sizeof(sk));
      |     ^~~~~~~~~~~~~~
asdf.c:436:9: warning: implicit declaration of function ‘fprintf’ [-Wimplicit-function-declaration]
  436 |         fprintf(stderr, "theirs != mine\en");
      |         ^~~~~~~
asdf.c:436:9: warning: incompatible implicit declaration of built-in function ‘fprintf’
asdf.c:4:1: note: include ‘<stdio.h>’ or provide a declaration of ‘fprintf’
    3 | #include <stdlib.h>
  +++ |+#include <stdio.h>
    4 | int main() {
asdf.c:436:17: error: ‘stderr’ undeclared (first use in this function)
  436 |         fprintf(stderr, "theirs != mine\en");
      |                 ^~~~~~
asdf.c:436:17: note: ‘stderr’ is defined in header ‘<stdio.h>’; did you forget to ‘#include <stdio.h>’?
asdf.c:439:5: warning: implicit declaration of function ‘puts’ [-Wimplicit-function-declaration]
  439 |     puts("ok");
      |     ^~~~
asdf.c: In function ‘main’:
asdf.c:482:26: warning: passing argument 2 of ‘crypto_hmac_sha512’ makes pointer from integer without a cast [-Wint-conversion]
  482 | crypto_hmac_sha512(hash, 64, key, 32, message, 500);
      |                          ^~
      |                          |
      |                          int
In file included from asdf.c:2:
../../../src/optional/monocypher-ed25519.h:103:40: note: expected ‘const uint8_t *’ {aka ‘const unsigned char *’} but argument is of type ‘int’
  103 |                         const uint8_t *key    , size_t key_size,
      |                         ~~~~~~~~~~~~~~~^~~
asdf.c:482:30: warning: passing argument 3 of ‘crypto_hmac_sha512’ makes integer from pointer without a cast [-Wint-conversion]
  482 | crypto_hmac_sha512(hash, 64, key, 32, message, 500);
      |                              ^~~
      |                              |
      |                              uint8_t * {aka unsigned char *}
In file included from asdf.c:2:
../../../src/optional/monocypher-ed25519.h:103:56: note: expected ‘size_t’ {aka ‘long unsigned int’} but argument is of type ‘uint8_t *’ {aka ‘unsigned char *’}
  103 |                         const uint8_t *key    , size_t key_size,
      |                                                 ~~~~~~~^~~~~~~~
asdf.c:482:35: warning: passing argument 4 of ‘crypto_hmac_sha512’ makes pointer from integer without a cast [-Wint-conversion]
  482 | crypto_hmac_sha512(hash, 64, key, 32, message, 500);
      |                                   ^~
      |                                   |
      |                                   int
In file included from asdf.c:2:
../../../src/optional/monocypher-ed25519.h:104:40: note: expected ‘const uint8_t *’ {aka ‘const unsigned char *’} but argument is of type ‘int’
  104 |                         const uint8_t *message, size_t message_size);
      |                         ~~~~~~~~~~~~~~~^~~~~~~
asdf.c:482:39: warning: passing argument 5 of ‘crypto_hmac_sha512’ makes integer from pointer without a cast [-Wint-conversion]
  482 | crypto_hmac_sha512(hash, 64, key, 32, message, 500);
      |                                       ^~~~~~~
      |                                       |
      |                                       uint8_t * {aka unsigned char *}
In file included from asdf.c:2:
../../../src/optional/monocypher-ed25519.h:104:56: note: expected ‘size_t’ {aka ‘long unsigned int’} but argument is of type ‘uint8_t *’ {aka ‘unsigned char *’}
  104 |                         const uint8_t *message, size_t message_size);
      |                                                 ~~~~~~~^~~~~~~~~~~~
asdf.c:482:1: error: too many arguments to function ‘crypto_hmac_sha512’
  482 | crypto_hmac_sha512(hash, 64, key, 32, message, 500);
      | ^~~~~~~~~~~~~~~~~~
In file included from asdf.c:2:
../../../src/optional/monocypher-ed25519.h:102:6: note: declared here
  102 | void crypto_hmac_sha512(uint8_t hmac[64],
      |      ^~~~~~~~~~~~~~~~~~
asdf.c:493:31: warning: passing argument 2 of ‘crypto_hmac_sha512_init’ makes pointer from integer without a cast [-Wint-conversion]
  493 | crypto_hmac_sha512_init(&ctx, 64, key, 32);
      |                               ^~
      |                               |
      |                               int
In file included from asdf.c:2:
../../../src/optional/monocypher-ed25519.h:98:45: note: expected ‘const uint8_t *’ {aka ‘const unsigned char *’} but argument is of type ‘int’
   98 |                              const uint8_t *key, size_t key_size);
      |                              ~~~~~~~~~~~~~~~^~~
asdf.c:493:35: warning: passing argument 3 of ‘crypto_hmac_sha512_init’ makes integer from pointer without a cast [-Wint-conversion]
  493 | crypto_hmac_sha512_init(&ctx, 64, key, 32);
      |                                   ^~~
      |                                   |
      |                                   uint8_t * {aka unsigned char *}
In file included from asdf.c:2:
../../../src/optional/monocypher-ed25519.h:98:57: note: expected ‘size_t’ {aka ‘long unsigned int’} but argument is of type ‘uint8_t *’ {aka ‘unsigned char *’}
   98 |                              const uint8_t *key, size_t key_size);
      |                                                  ~~~~~~~^~~~~~~~
asdf.c:493:1: error: too many arguments to function ‘crypto_hmac_sha512_init’
  493 | crypto_hmac_sha512_init(&ctx, 64, key, 32);
      | ^~~~~~~~~~~~~~~~~~~~~~~
In file included from asdf.c:2:
../../../src/optional/monocypher-ed25519.h:97:6: note: declared here
   97 | void crypto_hmac_sha512_init(crypto_hmac_sha512_ctx *ctx,
      |      ^~~~~~~~~~~~~~~~~~~~~~~
```