### PR TITLE
Some examples fixes

### DIFF
--- a/doc/man/man3/crypto_chacha20.3monocypher
+++ b/doc/man/man3/crypto_chacha20.3monocypher
@@ -243,7 +243,7 @@ const uint8_t key        [ 32]; /* Secret random key              */
 const uint8_t nonce      [ 24]; /* Unique nonce (possibly random) */
 const uint8_t plain_text [500]; /* Message to be encrypted        */
 uint8_t       cipher_text[500]; /* Will be the encrypted message  */
-crypto_xchacha20_encrypt(cipher_text, plain_text, 500, key, nonce);
+crypto_xchacha20(cipher_text, plain_text, 500, key, nonce);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(key,        32);
 crypto_wipe(plain_text, 500);
@@ -251,11 +251,11 @@ crypto_wipe(plain_text, 500);
 .Pp
 To decrypt the above:
 .Bd -literal -offset indent
-const uint8_t key        [ 32]; /* Same key as above              */
-const uint8_t nonce      [ 24]; /* Same nonce as above            */
-const uint8_t cipher_text[500]; /* Encrypted message              */
-uint8_t plain_text       [500]; /* Will be the decrypted message  */
-crypto_xchacha20_encrypt(cipher_text, plain_text, 500, key, nonce);
+const uint8_t key  [ 32]; /* Same key as above              */
+const uint8_t nonce[ 24]; /* Same nonce as above            */
+uint8_t plain_text [500]; /* Will be the decrypted message  */
+uint8_t cipher_text[500]; /* Encrypted message              */
+crypto_xchacha20(cipher_text, plain_text, 500, key, nonce);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(key,  32);
 /* The plain text likely needs to be processed before you wipe it */
@@ -269,15 +269,16 @@ const uint8_t nonce      [ 24]; /* Unique nonce (possibly random) */
 const uint8_t plain_text [500]; /* Message to be encrypted        */
 uint8_t       cipher_text[500]; /* Will be the encrypted message  */
 uint64_t      ctr;              /* Block counter */
-for(int i = 0; i < 500; i += 64) {
-    ctr = crypto_xchacha20_ctr(&ctx, cipher_text+i, plain_text+i,
-                               64, ctr);
+int i;
+for(i = 0; i < 500; i += 64) {
+    ctr = crypto_xchacha20_ctr(cipher_text+i, plain_text+i, 64,
+                               key, nonce, ctr);
 }
 /* Process data that didn't fit into 64 byte pieces */
-crypto_xchacha20_ctr(&ctx,
-                     cipher_text+500-(i-64),
+crypto_xchacha20_ctr(cipher_text+500-(i-64),
                      plain_text+500-(i-64),
-                     500-(i-64), ctr);
+                     500-(i-64),
+                     key, nonce, ctr);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(key,        32);
 crypto_wipe(plain_text, 500);
@@ -293,14 +294,12 @@ const uint8_t nonce      [ 24]; /* Unique nonce (possibly random) */
 const uint8_t plain_text [500]; /* Message to be encrypted        */
 uint8_t       cipher_text[500]; /* Will be the encrypted message  */
 /* Encrypt the second part of the message first... */
-crypto_chacha20(&ctx,
-                cipher_text + (3 * 64),
+crypto_chacha20(cipher_text + (3 * 64),
                 plain_text  + (3 * 64),
                 500         - (3 * 64),
-                key, nonce, 3);
+                key, nonce);
 /* ...then encrypt the first part */
-crypto_chacha20(&ctx, cipher_text, plain_text, 3 * 64,
-                key, nonce, 0);
+crypto_chacha20(cipher_text, plain_text, 3 * 64, key, nonce);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(key,        32);
 crypto_wipe(plain_text, 500);

--- a/doc/man/man3/crypto_sign_init_first_pass.3monocypher
+++ b/doc/man/man3/crypto_sign_init_first_pass.3monocypher
@@ -175,17 +175,17 @@ const uint8_t pk       [ 32]; /* Public key (optional) */
 const uint8_t message  [500]; /* Message to sign       */
 uint8_t       signature[ 64]; /* Output signature      */
 crypto_sign_ctx ctx;
-crypto_sign_init_first_pass(&ctx, sk, pk);
+crypto_sign_init_first_pass((crypto_sign_ctx_abstract*)&ctx, sk, pk);
 /* Wipe the secret key if no longer needed */
 crypto_wipe(sk, 32);
 for (size_t i = 0; i < 500; i += 100) {
-    crypto_sign_update(&ctx, message + i, 100);
+    crypto_sign_update((crypto_sign_ctx_abstract*)&ctx, message + i, 100);
 }
-crypto_sign_init_second_pass(&ctx);
+crypto_sign_init_second_pass((crypto_sign_ctx_abstract*)&ctx);
 for (size_t i = 0; i < 500; i += 100) {
-    crypto_sign_update(&ctx, message + i, 100);
+    crypto_sign_update((crypto_sign_ctx_abstract*)&ctx, message + i, 100);
 }
-crypto_sign_final(&ctx, signature);
+crypto_sign_final((crypto_sign_ctx_abstract*)&ctx, signature);
 .Ed
 .Pp
 Check the above:
@@ -194,11 +194,11 @@ const uint8_t pk       [ 32]; /* Public key         */
 const uint8_t message  [500]; /* Message to sign    */
 const uint8_t signature[ 64]; /* Signature to check */
 crypto_check_ctx ctx;
-crypto_check_init(&ctx, signature, pk);
+crypto_check_init((crypto_sign_ctx_abstract*)&ctx, signature, pk);
 for (size_t i = 0; i < 500; i += 100) {
-    crypto_check_update(&ctx, message + i, 100);
+    crypto_check_update((crypto_sign_ctx_abstract*)&ctx, message + i, 100);
 }
-if (crypto_check_final(&ctx)) {
+if (crypto_check_final((crypto_sign_ctx_abstract*)&ctx)) {
     /* Message is corrupted, abort processing */
 } else {
     /* Message is genuine */

--- a/doc/man/man3/optional/crypto_hmac_sha512.3monocypher
+++ b/doc/man/man3/optional/crypto_hmac_sha512.3monocypher
@@ -172,7 +172,7 @@ Computing a message authentication code all at once:
 uint8_t hash   [ 64]; /* Output hash  (between 1 and 64 bytes) */
 uint8_t key    [ 32]; /* Optional key (between 0 and 64 bytes) */
 uint8_t message[500]; /* Message to hash                       */
-crypto_hmac_sha512(hash, 64, key, 32, message, 500);
+crypto_hmac_sha512(hash, key, 32, message, 500);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(message, 500);
 crypto_wipe(key, 32);
@@ -184,7 +184,7 @@ uint8_t hash   [ 64]; /* Output hash  (between 1 and 64 bytes) */
 uint8_t key    [ 32]; /* Optional key (between 0 and 64 bytes) */
 uint8_t message[500]; /* Message to hash                       */
 crypto_hmac_sha512_ctx ctx;
-crypto_hmac_sha512_init(&ctx, 64, key, 32);
+crypto_hmac_sha512_init(&ctx, key, 32);
 /* Wipe the key */
 crypto_wipe(key, 32);
 for (size_t i = 0; i < 500; i += 100) {


### PR DESCRIPTION
Lots of the examples don't compile as C++ because they call crypto_wipe on const buffers

Having consts makes it a little clearer what's happening in the function calls that actually do the thing and these examples won't work by copy pasting them because they don't provide any data so IMO it's ok. It's not totally consistent right now so either way more changes are needed