### PR TITLE
dist.sh: Forgot copyright header for myself

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -12,6 +12,7 @@
 # ------------------------------------------------------------------------
 #
 # Copyright (c) 2019, Loup Vaillant
+# Copyright (c) 2019, Fabio Scotoni
 # All rights reserved.
 #
 #


### PR DESCRIPTION
Was just a one-line find(1) change, so one could argue removal of me in
the CC-0 header would've been cleaner,
but Loup wanted me to take credit for it (e-mail of Oct 21, 2019).

Correctly noted at the bottom in the CC-0 part.
I might need to write a script to consistency-check these at this rate.