### PR TITLE
Be more explicit about passwords in man pages

### DIFF
--- a/doc/man/man3/crypto_blake2b.3monocypher
+++ b/doc/man/man3/crypto_blake2b.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2018 Michael Savage
-.\" Copyright (c) 2017, 2019 Fabio Scotoni
+.\" Copyright (c) 2017, 2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 12, 2019
+.Dd February 5, 2020
 .Dt CRYPTO_BLAKE2B 3MONOCYPHER
 .Os
 .Sh NAME
@@ -104,6 +104,11 @@
 BLAKE2b is a fast cryptographically secure hash, based on the ideas of
 Chacha20.
 It is faster than MD5, yet just as secure as SHA-3.
+However, BLAKE2b itself
+.Sy is not suitable for hashing and deriving keys from passwords ;
+use the
+.Xr crypto_argon2i 3monocypher
+family of functions for that purpose instead.
 .Pp
 BLAKE2b is immune to length extension attacks, and as such does not
 require any specific precautions, such as using the HMAC algorithm.
@@ -276,3 +281,18 @@ Any deviation from the specified input and output length ranges results
 in
 .Sy undefined behaviour .
 Make sure your inputs are correct.
+.Sh SECURITY CONSIDERATIONS
+BLAKE2b is a general-purpose cryptographic hash function;
+this means that it is not suited for hashing passwords and deriving
+cryptographic keys from passwords in particular.
+While cryptographic keys usually have hundreds of bits of entropy,
+passwords are often much less complex.
+When storing passwords as hashes or when deriving keys from them,
+the goal is normally to prevent attackers from quickly iterating all
+possible passwords.
+Because passwords tend to be simple,
+it is important to artificially slow down attackers by using especially
+computationally difficult hashing algorithms.
+Monocypher therefore provides
+.Xr crypto_argon2i 3monocypher
+for password hashing and deriving keys from passwords.

--- a/doc/man/man3/crypto_blake2b.3monocypher
+++ b/doc/man/man3/crypto_blake2b.3monocypher
@@ -105,7 +105,7 @@ BLAKE2b is a fast cryptographically secure hash, based on the ideas of
 Chacha20.
 It is faster than MD5, yet just as secure as SHA-3.
 However, BLAKE2b itself
-.Sy is not suitable for hashing and deriving keys from passwords ;
+.Sy is not suitable for hashing passwords and deriving keys from them ;
 use the
 .Xr crypto_argon2i 3monocypher
 family of functions for that purpose instead.

--- a/doc/man/man3/intro.3monocypher
+++ b/doc/man/man3/intro.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2018 Michael Savage
-.\" Copyright (c) 2017, 2019 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 12, 2019
+.Dd February 5, 2020
 .Dt INTRO 3MONOCYPHER
 .Os
 .Sh NAME
@@ -59,7 +59,7 @@
 .Sh DESCRIPTION
 Monocypher is a cryptographic library.
 It provides functions for authenticated encryption, hashing, password
-key derivation, key exchange, and public key signatures.
+hashing and key derivation, key exchange, and public key signatures.
 .Ss Authenticated encryption
 .Xr crypto_lock 3monocypher
 and
@@ -88,9 +88,11 @@ implements the Blake2b hash.
 Blake2b combines the security of SHA-3 and the speed of MD5.
 It is immune to length extension attacks and provides a keyed mode
 that makes it a safe, easy to use authenticator.
-.Ss Password key derivation
+.Ss Password hashing and key derivation
 .Xr crypto_argon2i 3monocypher
-implements the Argon2i resource intensive hash algorithm.
+implements the Argon2i resource intensive hash algorithm,
+which can be used to hash passwords for storage and to derive keys
+from passwords.
 Argon2 won the password hashing competition in 2015.
 Unlike Scrypt, Argon2i is immune to timing attacks.
 .Ss Key exchange

--- a/doc/man/man3/optional/crypto_sha512.3monocypher
+++ b/doc/man/man3/optional/crypto_sha512.3monocypher
@@ -8,7 +8,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Copyright (c) 2019 Fabio Scotoni
+.\" Copyright (c) 2019-2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -38,7 +38,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2019 by Fabio Scotoni
+.\" Written in 2019-2020 by Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -48,7 +48,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 12, 2019
+.Dd February 5, 2020
 .Dt CRYPTO_SHA512 3MONOCYPHER
 .Os
 .Sh NAME
@@ -88,6 +88,11 @@ It is generally recommended to use
 instead,
 as it both performs faster on x86_64 CPUs and
 lacks many of the pitfalls of SHA-512.
+However, SHA-512 itself
+.Sy is not suitable for hashing and deriving keys from passwords ;
+use the
+.Xr crypto_argon2i 3monocypher
+family of functions for that purpose instead.
 .Pp
 SHA-512 is
 .Em vulnerable to length extension attacks ;
@@ -190,3 +195,18 @@ functions first appeared in Monocypher 0.3;
 they were not intended for use outside Monocypher itself and thus
 undocumented.
 They became part of the official API in Monocypher 3.0.0.
+.Sh SECURITY CONSIDERATIONS
+SHA-512 is a general-purpose cryptographic hash function;
+this means that it is not suited for hashing passwords and deriving
+cryptographic keys from passwords in particular.
+While cryptographic keys usually have hundreds of bits of entropy,
+passwords are often much less complex.
+When storing passwords as hashes or when deriving keys from them,
+the goal is normally to prevent attackers from quickly iterating all
+possible passwords.
+Because passwords tend to be simple,
+it is important to artificially slow down attackers by using especially
+computationally difficult hashing algorithms.
+Monocypher therefore provides
+.Xr crypto_argon2i 3monocypher
+for password hashing and deriving keys from passwords.

--- a/doc/man/man3/optional/crypto_sha512.3monocypher
+++ b/doc/man/man3/optional/crypto_sha512.3monocypher
@@ -89,7 +89,7 @@ instead,
 as it both performs faster on x86_64 CPUs and
 lacks many of the pitfalls of SHA-512.
 However, SHA-512 itself
-.Sy is not suitable for hashing and deriving keys from passwords ;
+.Sy is not suitable for hashing passwords and deriving keys from them ;
 use the
 .Xr crypto_argon2i 3monocypher
 family of functions for that purpose instead.


### PR DESCRIPTION
Prompted by an inquiry in #154.

---

The manual work this time is unusually deliberate in multiple ways.

**BLAKE2b/SHA-512**: The wording "BLAKE2b itself is not suitable" is a compromise between saying "*BLAKE2b is not suitable*" (which is an assertion I'm not comfortable making while PBKDF2 is still a thing that exists and can work with BLAKE2b as well as anything else—though one may certainly argue how appropriate PBKDF2 still is in times we bicker about Argon2 not having cache resistance) and "*BLAKE2b by itself is not suitable*" (which would correctly imply there are constructions that may be suitable, but then the question becomes "Why doesn't Monocypher just do this?", and that's one that would go far beyond what the manual is supposed to answer). I'm still not 100% happy with the wording I chose here, but it's an inconvenient tightrope either way.

**Security considerations**: I did pick up your idea from #154 to have a "Security Considerations" section, but I'm also okay with it being removed. You can't really talk about the issue at length because doing so would end up reinventing applied cryptography books while ultimately not providing much for the actual usage of the functions. While the SHA-512 page mostly refers to the BLAKE2b page, I've intentionally mirrored the "Security Considerations" section here in case people only selectively read the BLAKE2b page.

**Intro**: Mention password hashing right next to password key derivation. This should help prevent confusion about whether you want a "hash" function or a "password key derivation" function for passwords; the answer is always the latter. This slightly stretches the meaning of the original wording to go beyond what used to be since the relationship between password key derivation and password hashing is a non-trivial one, but this change helps the uninitiated and does no harm for the experienced reader. This may need a corresponding change in the sidebar of the manual on the website.

Authorship notices and mdoc dates bumped as required.