### PR TITLE
Add random_bytes() to crypto_lock examples

### DIFF
--- a/doc/extract_examples.sh
+++ b/doc/extract_examples.sh
@@ -58,16 +58,12 @@ cat << END
 #include "../src/monocypher.h"
 #include "../src/optional/monocypher-ed25519.h"
 
-typedef struct SHA2_CTX { } SHA2_CTX;
+typedef struct SHA2_CTX { void *x; } SHA2_CTX;
 void SHA512Init(SHA2_CTX*);
 void SHA512Update(SHA2_CTX*, const void*, size_t);
 void SHA512Final(uint8_t*, SHA2_CTX*);
 void arc4random_buf(void*, size_t);
 
-static void random_bytes(uint8_t *buf, size_t len)
-{
-    arc4random_buf(buf, len);
-}
 
 int main() {
 END

--- a/doc/extract_examples.sh
+++ b/doc/extract_examples.sh
@@ -12,6 +12,7 @@
 # ------------------------------------------------------------------------
 #
 # Copyright (c) 2019 Michael Savage
+# Copyright (c) 2020 Fabio Scotoni
 # All rights reserved.
 #
 #
@@ -41,7 +42,7 @@
 #
 # ------------------------------------------------------------------------
 #
-# Written in 2019 by Michael Savage
+# Written in 2019-2020 by Michael Savage and Fabio Scotoni
 #
 # To the extent possible under law, the author(s) have dedicated all copyright
 # and related neighboring rights to this software to the public domain
@@ -62,6 +63,11 @@ void SHA512Init(SHA2_CTX*);
 void SHA512Update(SHA2_CTX*, const void*, size_t);
 void SHA512Final(uint8_t*, SHA2_CTX*);
 void arc4random_buf(void*, size_t);
+
+static void random_bytes(uint8_t *buf, size_t len)
+{
+    arc4random_buf(buf, len);
+}
 
 int main() {
 END

--- a/doc/man/man3/crypto_argon2i.3monocypher
+++ b/doc/man/man3/crypto_argon2i.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2018 Michael Savage
-.\" Copyright (c) 2017, 2019 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 12, 2019
+.Dd March 2, 2020
 .Dt CRYPTO_ARGON2I 3MONOCYPHER
 .Os
 .Sh NAME
@@ -235,26 +235,39 @@ Must be zero if there is no additional data.
 .Sh RETURN VALUES
 These functions return nothing.
 .Sh EXAMPLES
+The following example assumes the existence of
+.Fn arc4random_buf ,
+which fills the given buffer with cryptographically secure random bytes.
+If
+.Fn arc4random_buf
+does not exist on your system, see
+.Xr intro 3monocypher
+for advice about how to generate cryptographically secure random bytes.
+.Pp
 This example shows how to hash a password with the recommended baseline
 parameters:
 .Bd -literal -offset indent
 uint8_t        hash[32];                    /* Output hash     */
-uint8_t       *password;                    /* User's password */
-uint8_t        password_size;               /* Password length */
-const uint8_t  salt[16];                    /* Random salt     */
+char          *password = "Okay Password!"; /* User's password */
+uint32_t       password_size = 14;          /* Password length */
+uint8_t        salt[16];                    /* Random salt     */
 const uint32_t nb_blocks = 100000;          /* 100 megabytes   */
 const uint32_t nb_iterations = 3;           /* 3 iterations    */
 void *work_area = malloc(nb_blocks * 1024); /* Work area       */
 if (work_area == NULL) {
     /* Handle malloc() failure */
+    /* Wipe secrets if they are no longer needed */
+    crypto_wipe(password, password_size);
+} else {
+    arc4random_buf(salt, 16);
+    crypto_argon2i(hash, 32,
+                   work_area, nb_blocks, nb_iterations,
+                   (uint8_t *)password, password_size,
+                   salt, 16);
+    /* Wipe secrets if they are no longer needed */
+    crypto_wipe(password, password_size);
+    free(work_area);
 }
-crypto_argon2i(hash, 32,
-               work_area, nb_blocks, nb_iterations,
-               password, password_size,
-               salt, 16);
-/* Wipe secrets if they are no longer needed */
-crypto_wipe(password, password_size);
-free(work_area);
 .Ed
 .Sh SEE ALSO
 .Xr crypto_lock 3monocypher ,

--- a/doc/man/man3/crypto_blake2b.3monocypher
+++ b/doc/man/man3/crypto_blake2b.3monocypher
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd February 5, 2020
+.Dd March 2, 2020
 .Dt CRYPTO_BLAKE2B 3MONOCYPHER
 .Os
 .Sh NAME
@@ -214,28 +214,38 @@ This is considered a good default.
 .Sh RETURN VALUES
 These functions return nothing.
 .Sh EXAMPLES
+The following examples assume the existence of
+.Fn arc4random_buf ,
+which fills the given buffer with cryptographically secure random bytes.
+If
+.Fn arc4random_buf
+does not exist on your system, see
+.Xr intro 3monocypher
+for advice about how to generate cryptographically secure random bytes.
+.Pp
 Hashing a message all at once:
 .Bd -literal -offset indent
-uint8_t hash   [ 64]; /* Output hash (64 bytes) */
-uint8_t message[500]; /* Message to hash        */
-crypto_blake2b(hash, message, 500);
+uint8_t hash   [64]; /* Output hash (64 bytes)          */
+uint8_t message[12] = "Lorem ipsum"; /* Message to hash */
+crypto_blake2b(hash, message, 12);
 .Ed
 .Pp
 Computing a message authentication code all at once:
 .Bd -literal -offset indent
-uint8_t hash   [ 64]; /* Output hash  (between 1 and 64 bytes) */
-uint8_t key    [ 32]; /* Optional key (between 0 and 64 bytes) */
-uint8_t message[500]; /* Message to hash                       */
-crypto_blake2b_general(hash, 64, key, 32, message, 500);
+uint8_t hash   [64]; /* Output hash  (between 1 and 64 bytes)  */
+uint8_t key    [32]; /* Key          (between 1 and 64 bytes)  */
+uint8_t message[11] = "Lorem ipsu"; /* Message to authenticate */
+arc4random_buf(key, 32);
+crypto_blake2b_general(hash, 64, key, 32, message, 11);
 /* Wipe secrets if they are no longer needed */
-crypto_wipe(message, 500);
+crypto_wipe(message, 11);
 crypto_wipe(key, 32);
 .Ed
 .Pp
-Hashing a message incrementally:
+Hashing a message incrementally (without a key):
 .Bd -literal -offset indent
 uint8_t hash   [ 64]; /* Output hash (64 bytes) */
-uint8_t message[500]; /* Message to hash        */
+uint8_t message[500] = {1}; /* Message to hash  */
 crypto_blake2b_ctx ctx;
 crypto_blake2b_init(&ctx);
 for (size_t i = 0; i < 500; i += 100) {
@@ -247,9 +257,10 @@ crypto_blake2b_final(&ctx, hash);
 Computing a message authentication code incrementally:
 .Bd -literal -offset indent
 uint8_t hash   [ 64]; /* Output hash  (between 1 and 64 bytes) */
-uint8_t key    [ 32]; /* Optional key (between 0 and 64 bytes) */
-uint8_t message[500]; /* Message to hash                       */
+uint8_t key    [ 32]; /* Key          (between 1 and 64 bytes) */
+uint8_t message[500] = {1}; /* Message to authenticate         */
 crypto_blake2b_ctx ctx;
+arc4random_buf(key, 32);
 crypto_blake2b_general_init(&ctx, 64, key, 32);
 /* Wipe the key */
 crypto_wipe(key, 32);

--- a/doc/man/man3/crypto_chacha20.3monocypher
+++ b/doc/man/man3/crypto_chacha20.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2018 Michael Savage
-.\" Copyright (c) 2017, 2019 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 4, 2019
+.Dd March 2, 2020
 .Dt CRYPTO_CHACHA20 3MONOCYPHER
 .Os
 .Sh NAME
@@ -237,12 +237,23 @@ this is always
 divided by 64;
 plus one if there was a remainder.
 .Sh EXAMPLES
+The following examples assume the existence of
+.Fn arc4random_buf ,
+which fills the given buffer with cryptographically secure random bytes.
+If
+.Fn arc4random_buf
+does not exist on your system, see
+.Xr intro 3monocypher
+for advice about how to generate cryptographically secure random bytes.
+.Pp
 Simple encryption:
 .Bd -literal -offset indent
-uint8_t       key        [ 32]; /* Secret random key              */
-const uint8_t nonce      [ 24]; /* Unique nonce (possibly random) */
-uint8_t       plain_text [500]; /* Message to be encrypted        */
-uint8_t       cipher_text[500]; /* Will be the encrypted message  */
+uint8_t key        [ 32]; /* Secret random key              */
+uint8_t nonce      [ 24]; /* Unique nonce (possibly random) */
+uint8_t plain_text [500] = {1}; /* Secret message           */
+uint8_t cipher_text[500]; /* Encrypted message              */
+arc4random_buf(key,   32);
+arc4random_buf(nonce, 24);
 crypto_xchacha20(cipher_text, plain_text, 500, key, nonce);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(key,        32);
@@ -251,25 +262,27 @@ crypto_wipe(plain_text, 500);
 .Pp
 To decrypt the above:
 .Bd -literal -offset indent
-uint8_t       key  [ 32]; /* Same key as above              */
-const uint8_t nonce[ 24]; /* Same nonce as above            */
-uint8_t plain_text [500]; /* Will be the decrypted message  */
-uint8_t cipher_text[500]; /* Encrypted message              */
+uint8_t       key        [ 32]; /* Same key as above        */
+const uint8_t nonce      [ 24]; /* Same nonce as above      */
+uint8_t       plain_text [500]; /* Message to decrypt       */
+uint8_t       cipher_text[500]; /* Secret message           */
 crypto_xchacha20(cipher_text, plain_text, 500, key, nonce);
 /* Wipe secrets if they are no longer needed */
-crypto_wipe(key,  32);
+crypto_wipe(key,        32);
 /* The plain text likely needs to be processed before you wipe it */
-crypto_wipe(plain_text, 500);
+crypto_wipe(plain_text, 12);
 .Ed
 .Pp
 Incremental encryption (in blocks of 64 bytes):
 .Bd -literal -offset indent
-uint8_t       key        [ 32]; /* Secret random key              */
-const uint8_t nonce      [ 24]; /* Unique nonce (possibly random) */
-uint8_t       plain_text [500]; /* Message to be encrypted        */
-uint8_t       cipher_text[500]; /* Will be the encrypted message  */
-uint64_t      ctr;              /* Block counter */
-int i;
+uint8_t  key        [ 32]; /* Secret random key              */
+uint8_t  nonce      [ 24]; /* Unique nonce (possibly random) */
+uint8_t  plain_text [500]; /* Secret message                 */
+uint8_t  cipher_text[500]; /* Encrypted message              */
+uint64_t ctr = 0;          /* Block counter                  */
+unsigned int i;
+arc4random_buf(key,   32);
+arc4random_buf(nonce, 24);
 for(i = 0; i < 500; i += 64) {
     ctr = crypto_xchacha20_ctr(cipher_text+i, plain_text+i, 64,
                                key, nonce, ctr);
@@ -289,17 +302,19 @@ how
 .Fn crypto_xchacha20_ctr
 works):
 .Bd -literal -offset indent
-uint8_t       key        [ 32]; /* Secret random key              */
-const uint8_t nonce      [ 24]; /* Unique nonce (possibly random) */
-uint8_t       plain_text [500]; /* Message to be encrypted        */
-uint8_t       cipher_text[500]; /* Will be the encrypted message  */
+uint8_t key        [ 32]; /* Secret random key              */
+uint8_t nonce      [ 24]; /* Unique nonce (possibly random) */
+uint8_t plain_text [500] = {1}; /* Message to be encrypted  */
+uint8_t cipher_text[500]; /* Will be the encrypted message  */
+arc4random_buf(key,   32);
+arc4random_buf(nonce, 24);
 /* Encrypt the second part of the message first... */
-crypto_chacha20(cipher_text + (3 * 64),
-                plain_text  + (3 * 64),
-                500         - (3 * 64),
-                key, nonce);
+crypto_xchacha20_ctr(cipher_text + (3 * 64),
+                     plain_text  + (3 * 64),
+                     500         - (3 * 64),
+                     key, nonce, 3);
 /* ...then encrypt the first part */
-crypto_chacha20(cipher_text, plain_text, 3 * 64, key, nonce);
+crypto_xchacha20_ctr(cipher_text, plain_text, 3 * 64, key, nonce, 0);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(key,        32);
 crypto_wipe(plain_text, 500);

--- a/doc/man/man3/crypto_hchacha20.3monocypher
+++ b/doc/man/man3/crypto_hchacha20.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2019 Fabio Scotoni
+.\" Copyright (c) 2019-2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 12, 2019
+.Dd March 2, 2020
 .Dt CRYPTO_HCHACHA20 3MONOCYPHER
 .Os
 .Sh NAME
@@ -92,11 +92,21 @@ X25519 shared secrets have enough entropy.
 .Sh RETURN VALUES
 This function returns nothing.
 .Sh EXAMPLES
+The following example assumes the existence of
+.Fn arc4random_buf ,
+which fills the given buffer with cryptographically secure random bytes.
+If
+.Fn arc4random_buf
+does not exist on your system, see
+.Xr intro 3monocypher
+for advice about how to generate cryptographically secure random bytes.
+.Pp
 Simple hash:
 .Bd -literal -offset indent
 uint8_t key[32]; /* Must have enough entropy           */
 uint8_t in [16]; /* Does not have to be random         */
 uint8_t out[32]; /* Will be random iff the above holds */
+arc4random_buf(key, 32);
 crypto_hchacha20(out, key, in);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(key, 32);

--- a/doc/man/man3/crypto_key_exchange.3monocypher
+++ b/doc/man/man3/crypto_key_exchange.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2017, 2019 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 12, 2019
+.Dd March 2, 2020
 .Dt CRYPTO_KEY_EXCHANGE 3MONOCYPHER
 .Os
 .Sh NAME
@@ -115,10 +115,20 @@ Protocols should instead be designed in such a way that no such check
 is necessary, namely by authenticating the other party or exchanging
 keys over a trusted channel.
 .Sh EXAMPLES
+The following examples assume the existence of
+.Fn arc4random_buf ,
+which fills the given buffer with cryptographically secure random bytes.
+If
+.Fn arc4random_buf
+does not exist on your system, see
+.Xr intro 3monocypher
+for advice about how to generate cryptographically secure random bytes.
+.Pp
 Generate a public key from a randomly generated secret key:
 .Bd -literal -offset indent
 uint8_t sk[32]; /* Random secret key */
 uint8_t pk[32]; /* Public key        */
+arc4random_buf(sk, 32);
 crypto_key_exchange_public_key(pk, sk);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(sk, 32);

--- a/doc/man/man3/crypto_lock.3monocypher
+++ b/doc/man/man3/crypto_lock.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2017, 2019 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 12, 2019
+.Dd February 29, 2020
 .Dt CRYPTO_LOCK 3MONOCYPHER
 .Os
 .Sh NAME
@@ -226,6 +226,21 @@ attacker's interference.
 .Fa plain_text
 does not need to be wiped if the decryption fails.
 .Sh EXAMPLES
+The following examples assume that a function called
+.Fn random_bytes
+exists.
+It fills the given buffer with cryptographically secure random
+bytes
+(see
+.Xr intro 3monocypher
+for some advice on how to accomplish this yourself).
+The function has this prototype:
+.Ft void
+.Fo random_bytes
+.Fa "uint8_t *buf"
+.Fa "size_t len"
+.Fc
+.Pp
 Encryption:
 .Bd -literal -offset indent
 uint8_t       key        [32];  /* Random, secret session key  */
@@ -233,11 +248,14 @@ const uint8_t nonce      [24];  /* Use only once per key       */
 uint8_t       plain_text [500]; /* Secret message              */
 uint8_t       mac        [16];  /* Message authentication code */
 uint8_t       cipher_text[500]; /* Encrypted message           */
+random_bytes(key, 32);
 crypto_lock(mac, cipher_text, key, nonce, plain_text, 500);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(plain_text, 500);
 crypto_wipe(key, 32);
-/* Transmit cipher_text, nonce, and mac over the network */
+/* Transmit cipher_text, nonce, and mac over the network,
+ * store them in a file, etc.
+ */
 .Ed
 .Pp
 To decrypt the above:
@@ -253,10 +271,12 @@ if (crypto_unlock(plain_text, key, nonce, mac, cipher_text, 500)) {
      * and abort the decryption.
      */
     crypto_wipe(key, 32);
+} else {
+    /* ...do something with the decrypted text here... */
+    /* Finally, wipe secrets if they are no longer needed */
+    crypto_wipe(plain_text, 500);
+    crypto_wipe(key, 32);
 }
-/* Wipe secrets if they are no longer needed */
-crypto_wipe(plain_text, 500);
-crypto_wipe(key, 32);
 .Ed
 .Pp
 In-place encryption:
@@ -265,10 +285,13 @@ uint8_t       key  [32];  /* Random, secret session key  */
 const uint8_t nonce[24];  /* Use only once per key       */
 uint8_t       text [500]; /* Secret message              */
 uint8_t       mac  [16];  /* Message authentication code */
+random_bytes(key, 32);
 crypto_lock(mac, text, key, nonce, text, 500);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(key, 32);
-/* Transmit text, nonce, and mac over the network */
+/* Transmit cipher_text, nonce, and mac over the network,
+ * store them in a file, etc.
+ */
 .Ed
 .Pp
 In-place decryption:
@@ -283,10 +306,12 @@ if (crypto_unlock(text, key, nonce, mac, text, 500)) {
      * and abort the decryption.
      */
     crypto_wipe(key, 32);
+} else {
+    /* ...do something with the decrypted text here... */
+    /* Finally, wipe secrets if they are no longer needed */
+    crypto_wipe(text, 500);
+    crypto_wipe(key, 32);
 }
-/* Wipe secrets if they are no longer needed */
-crypto_wipe(text, 500);
-crypto_wipe(key, 32);
 .Ed
 .Sh SEE ALSO
 .Xr crypto_key_exchange 3monocypher ,

--- a/doc/man/man3/crypto_lock.3monocypher
+++ b/doc/man/man3/crypto_lock.3monocypher
@@ -226,32 +226,28 @@ attacker's interference.
 .Fa plain_text
 does not need to be wiped if the decryption fails.
 .Sh EXAMPLES
-The following examples assume that a function called
-.Fn random_bytes
-exists.
-It fills the given buffer with cryptographically secure random
-bytes
-(see
+The following examples assume the existence of
+.Fn arc4random_buf ,
+which fills the given buffer with cryptographically secure random bytes.
+If
+.Fn arc4random_buf
+does not exist on your system, see
 .Xr intro 3monocypher
-for some advice on how to accomplish this yourself).
-The function has this prototype:
-.Ft void
-.Fo random_bytes
-.Fa "uint8_t *buf"
-.Fa "size_t len"
-.Fc
+for advice about how to generate cryptographically secure random bytes.
 .Pp
 Encryption:
 .Bd -literal -offset indent
-uint8_t       key        [32];  /* Random, secret session key  */
-const uint8_t nonce      [24];  /* Use only once per key       */
-uint8_t       plain_text [500]; /* Secret message              */
-uint8_t       mac        [16];  /* Message authentication code */
-uint8_t       cipher_text[500]; /* Encrypted message           */
-random_bytes(key, 32);
-crypto_lock(mac, cipher_text, key, nonce, plain_text, 500);
+uint8_t key        [32];    /* Random, secret session key  */
+uint8_t nonce      [24];    /* Use only once per key       */
+uint8_t plain_text [12] = "Lorem ipsum"; /* Secret message */
+uint8_t mac        [16];    /* Message authentication code */
+uint8_t cipher_text[12];              /* Encrypted message */
+arc4random_buf(key,   32);
+arc4random_buf(nonce, 24);
+crypto_lock(mac, cipher_text, key, nonce, plain_text,
+        sizeof(plain_text));
 /* Wipe secrets if they are no longer needed */
-crypto_wipe(plain_text, 500);
+crypto_wipe(plain_text, 12);
 crypto_wipe(key, 32);
 /* Transmit cipher_text, nonce, and mac over the network,
  * store them in a file, etc.
@@ -260,12 +256,12 @@ crypto_wipe(key, 32);
 .Pp
 To decrypt the above:
 .Bd -literal -offset indent
-uint8_t       key        [32];  /* Same as the above         */
-const uint8_t nonce      [24];  /* Same as the above         */
-const uint8_t cipher_text[500]; /* Encrypted message         */
-const uint8_t mac        [16];  /* Received from the network */
-uint8_t       plain_text [500]; /* Secret message            */
-if (crypto_unlock(plain_text, key, nonce, mac, cipher_text, 500)) {
+uint8_t       key        [32]; /* Same as the above        */
+uint8_t       nonce      [24]; /* Same as the above        */
+const uint8_t cipher_text[12]; /* Encrypted message        */
+const uint8_t mac        [16]; /* Received along with text */
+uint8_t       plain_text [12]; /* Secret message           */
+if (crypto_unlock(plain_text, key, nonce, mac, cipher_text, 12)) {
     /* The message is corrupted.
      * Wipe key if it is no longer needed,
      * and abort the decryption.
@@ -274,19 +270,20 @@ if (crypto_unlock(plain_text, key, nonce, mac, cipher_text, 500)) {
 } else {
     /* ...do something with the decrypted text here... */
     /* Finally, wipe secrets if they are no longer needed */
-    crypto_wipe(plain_text, 500);
+    crypto_wipe(plain_text, 12);
     crypto_wipe(key, 32);
 }
 .Ed
 .Pp
 In-place encryption:
 .Bd -literal -offset indent
-uint8_t       key  [32];  /* Random, secret session key  */
-const uint8_t nonce[24];  /* Use only once per key       */
-uint8_t       text [500]; /* Secret message              */
-uint8_t       mac  [16];  /* Message authentication code */
-random_bytes(key, 32);
-crypto_lock(mac, text, key, nonce, text, 500);
+uint8_t key  [32];    /* Random, secret session key  */
+uint8_t nonce[24];    /* Use only once per key       */
+uint8_t text [12] = "Lorem ipsum"; /* Secret message */
+uint8_t mac  [16];    /* Message authentication code */
+arc4random_buf(key,   32);
+arc4random_buf(nonce, 24);
+crypto_lock(mac, text, key, nonce, text, 12);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(key, 32);
 /* Transmit cipher_text, nonce, and mac over the network,
@@ -296,11 +293,11 @@ crypto_wipe(key, 32);
 .Pp
 In-place decryption:
 .Bd -literal -offset indent
-uint8_t        key  [32];  /* Same as the above         */
-const uint8_t  nonce[24];  /* Same as the above         */
-const uint8_t  mac  [16];  /* Received from the network */
-uint8_t        text [500]; /* Message to decrypt        */
-if (crypto_unlock(text, key, nonce, mac, text, 500)) {
+uint8_t        key  [32]; /* Same as the above             */
+const uint8_t  nonce[24]; /* Same as the above             */
+const uint8_t  mac  [16]; /* Received from along with text */
+uint8_t        text [12]; /* Message to decrypt            */
+if (crypto_unlock(text, key, nonce, mac, text, 12)) {
     /* The message is corrupted.
      * Wipe key if it is no longer needed,
      * and abort the decryption.
@@ -309,7 +306,7 @@ if (crypto_unlock(text, key, nonce, mac, text, 500)) {
 } else {
     /* ...do something with the decrypted text here... */
     /* Finally, wipe secrets if they are no longer needed */
-    crypto_wipe(text, 500);
+    crypto_wipe(text, 12);
     crypto_wipe(key, 32);
 }
 .Ed

--- a/doc/man/man3/crypto_poly1305.3monocypher
+++ b/doc/man/man3/crypto_poly1305.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2017-2019 Fabio Scotoni
+.\" Copyright (c) 2017-2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 12, 2019
+.Dd March 2, 2020
 .Dt CRYPTO_POLY1305 3MONOCYPHER
 .Os
 .Sh NAME
@@ -139,23 +139,33 @@ yields the message authentication code.
 .Sh RETURN VALUES
 These functions return nothing.
 .Sh EXAMPLES
+The following examples assume the existence of
+.Fn arc4random_buf ,
+which fills the given buffer with cryptographically secure random bytes.
+If
+.Fn arc4random_buf
+does not exist on your system, see
+.Xr intro 3monocypher
+for advice about how to generate cryptographically secure random bytes.
+.Pp
 To authenticate a message:
 .Bd -literal -offset indent
-const uint8_t msg[500]; /* Message to authenticate           */
-uint8_t       key[ 32]; /* Random secret key (use only once) */
-uint8_t       mac[ 16]; /* Message authentication code (MAC) */
-crypto_poly1305(mac, msg, 500, key);
+const uint8_t msg[ 5] = "Lorem"; /* Message to authenticate */
+uint8_t       key[32]; /* Random secret key (use only once) */
+uint8_t       mac[16]; /* Message authentication code (MAC) */
+arc4random_buf(key, 32);
+crypto_poly1305(mac, msg, 5, key);
 /* Wipe the key */
 crypto_wipe(key, 32);
 .Ed
 .Pp
 To verify the above message:
 .Bd -literal -offset indent
-const uint8_t msg     [500]; /* Message to verify */
-uint8_t       key     [ 32]; /* The above key     */
-const uint8_t mac     [ 16]; /* The above MAC     */
-uint8_t       real_mac[ 16]; /* The actual MAC    */
-crypto_poly1305(real_mac, msg, 500, key);
+const uint8_t msg     [ 5] = "Lorem"; /* Message to verify */
+uint8_t       key     [32];           /* The above key     */
+const uint8_t mac     [16];           /* The above MAC     */
+uint8_t       real_mac[16];           /* The actual MAC    */
+crypto_poly1305(real_mac, msg, 5, key);
 /* Wipe the key */
 crypto_wipe(key, 32);
 if (crypto_verify16(mac, real_mac)) {
@@ -169,10 +179,11 @@ crypto_wipe(real_mac, 16);
 .Pp
 Incremental authentication:
 .Bd -literal -offset indent
-const uint8_t msg[500]; /* Message to authenticate           */
+const uint8_t msg[500]= {1}; /* Message to authenticate      */
 uint8_t       key[ 32]; /* Random secret key (use only once) */
 uint8_t       mac[ 16]; /* Message authentication code (MAC) */
 crypto_poly1305_ctx ctx;
+arc4random_buf(key, 32);
 crypto_poly1305_init(&ctx, key);
 /* Wipe the key */
 crypto_wipe(key, 32);

--- a/doc/man/man3/crypto_sign.3monocypher
+++ b/doc/man/man3/crypto_sign.3monocypher
@@ -173,7 +173,7 @@ Sign a message:
 .Bd -literal -offset indent
 uint8_t       sk       [32]; /* Secret key from above          */
 const uint8_t pk       [32]; /* Matching public key            */
-const uint8_t message  [10] = "Lorem ipsu"; /* Message to sign */
+const uint8_t message  [11] = "Lorem ipsu"; /* Message to sign */
 uint8_t       signature[64];
 crypto_sign(signature, sk, pk, message, 10);
 /* Wipe the secret key if it is no longer needed */
@@ -183,7 +183,7 @@ crypto_wipe(sk, 32);
 Check the above:
 .Bd -literal -offset indent
 const uint8_t pk       [32]; /* Their public key              */
-const uint8_t message  [10] = "Lorem ipsu"; /* Signed message */
+const uint8_t message  [11] = "Lorem ipsu"; /* Signed message */
 const uint8_t signature[64]; /* Signature to check            */
 if (crypto_check(signature, pk, message, 10)) {
     /* Message is corrupted, abort processing */

--- a/doc/man/man3/crypto_sign.3monocypher
+++ b/doc/man/man3/crypto_sign.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2017, 2019 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 12, 2019
+.Dd March 2, 2020
 .Dt CRYPTO_SIGN 3MONOCYPHER
 .Os
 .Sh NAME
@@ -150,10 +150,20 @@ return nothing.
 .Fn crypto_check
 returns 0 for legitimate messages and -1 for forgeries.
 .Sh EXAMPLES
+The following examples assume the existence of
+.Fn arc4random_buf ,
+which fills the given buffer with cryptographically secure random bytes.
+If
+.Fn arc4random_buf
+does not exist on your system, see
+.Xr intro 3monocypher
+for advice about how to generate cryptographically secure random bytes.
+.Pp
 Generate a public key from a random secret key:
 .Bd -literal -offset indent
 uint8_t       sk[32]; /* Random secret key   */
 uint8_t       pk[32]; /* Matching public key */
+arc4random_buf(sk, 32);
 crypto_sign_public_key(pk, sk);
 /* Wipe the secret key if it is no longer needed */
 crypto_wipe(sk, 32);
@@ -161,21 +171,21 @@ crypto_wipe(sk, 32);
 .Pp
 Sign a message:
 .Bd -literal -offset indent
-uint8_t       sk       [ 32]; /* Your secret key     */
-const uint8_t pk       [ 32]; /* Matching public key */
-const uint8_t message  [500]; /* Message to sign     */
-uint8_t       signature[ 64];
-crypto_sign(signature, sk, pk, message, 500);
+uint8_t       sk       [32]; /* Secret key from above          */
+const uint8_t pk       [32]; /* Matching public key            */
+const uint8_t message  [10] = "Lorem ipsu"; /* Message to sign */
+uint8_t       signature[64];
+crypto_sign(signature, sk, pk, message, 10);
 /* Wipe the secret key if it is no longer needed */
 crypto_wipe(sk, 32);
 .Ed
 .Pp
 Check the above:
 .Bd -literal -offset indent
-const uint8_t pk       [ 32]; /* Their public key   */
-const uint8_t message  [500]; /* Signed message     */
-const uint8_t signature[ 64]; /* Signature to check */
-if (crypto_check(signature, pk, message, 500)) {
+const uint8_t pk       [32]; /* Their public key              */
+const uint8_t message  [10] = "Lorem ipsu"; /* Signed message */
+const uint8_t signature[64]; /* Signature to check            */
+if (crypto_check(signature, pk, message, 10)) {
     /* Message is corrupted, abort processing */
 } else {
     /* Message is genuine */

--- a/doc/man/man3/crypto_x25519.3monocypher
+++ b/doc/man/man3/crypto_x25519.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2017, 2019 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 12, 2019
+.Dd March 2, 2020
 .Dt CRYPTO_X25519 3MONOCYPHER
 .Os
 .Sh NAME
@@ -121,6 +121,15 @@ Protocols should instead be designed in such a way that no such check
 is necessary, namely by authenticating the other party or exchanging
 keys over a trusted channel.
 .Sh EXAMPLES
+The following example assumes the existence of
+.Fn arc4random_buf ,
+which fills the given buffer with cryptographically secure random bytes.
+If
+.Fn arc4random_buf
+does not exist on your system, see
+.Xr intro 3monocypher
+for advice about how to generate cryptographically secure random bytes.
+.Pp
 Generate a pair of shared keys with your secret key and their public
 key.
 (This can help nonce management for full duplex communications.)
@@ -128,6 +137,7 @@ key.
 const uint8_t their_pk     [32]; /* Their public key          */
 uint8_t       your_sk      [32]; /* Your secret key           */
 uint8_t       shared_secret[32]; /* Shared secret (NOT a key) */
+arc4random_buf(your_sk, 32);
 crypto_x25519(shared_secret, your_sk, their_pk);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(your_sk, 32);

--- a/doc/man/man3/optional/crypto_hmac_sha512.3monocypher
+++ b/doc/man/man3/optional/crypto_hmac_sha512.3monocypher
@@ -8,7 +8,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Copyright (c) 2019 Fabio Scotoni
+.\" Copyright (c) 2019-2020 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -38,7 +38,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2019 by Fabio Scotoni
+.\" Written in 2019-2020 by Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -48,7 +48,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 12, 2019
+.Dd March 2, 2020
 .Dt CRYPTO_HMAC_SHA512 3MONOCYPHER
 .Os
 .Sh NAME
@@ -167,11 +167,21 @@ functions can be used to to compare (possibly truncated) MACs.
 .Sh RETURN VALUES
 These functions return nothing.
 .Sh EXAMPLES
+The following examples assume the existence of
+.Fn arc4random_buf ,
+which fills the given buffer with cryptographically secure random bytes.
+If
+.Fn arc4random_buf
+does not exist on your system, see
+.Xr intro 3monocypher
+for advice about how to generate cryptographically secure random bytes.
+.Pp
 Computing a message authentication code all at once:
 .Bd -literal -offset indent
-uint8_t hash   [ 64]; /* Output hash  (between 1 and 64 bytes) */
-uint8_t key    [ 32]; /* Optional key (between 0 and 64 bytes) */
-uint8_t message[500]; /* Message to hash                       */
+uint8_t hash   [64]; /* Output hash  (between 1 and 64 bytes)  */
+uint8_t key    [32]; /* Key          (at least 1 byte)         */
+uint8_t message[10] = "Lorem ipsu"; /* Message to authenticate */
+arc4random_buf(key, 32);
 crypto_hmac_sha512(hash, key, 32, message, 500);
 /* Wipe secrets if they are no longer needed */
 crypto_wipe(message, 500);
@@ -180,10 +190,11 @@ crypto_wipe(key, 32);
 .Pp
 Computing a message authentication code incrementally:
 .Bd -literal -offset indent
-uint8_t hash   [ 64]; /* Output hash  (between 1 and 64 bytes) */
-uint8_t key    [ 32]; /* Optional key (between 0 and 64 bytes) */
-uint8_t message[500]; /* Message to hash                       */
+uint8_t hash   [64]; /* Output hash  (between 1 and 64 bytes)  */
+uint8_t key    [32]; /* Key          (at least 1 byte)         */
+uint8_t message[500] = {1}; /* Message to authenticate         */
 crypto_hmac_sha512_ctx ctx;
+arc4random_buf(key, 32);
 crypto_hmac_sha512_init(&ctx, key, 32);
 /* Wipe the key */
 crypto_wipe(key, 32);

--- a/doc/man/man3/optional/crypto_sha512.3monocypher
+++ b/doc/man/man3/optional/crypto_sha512.3monocypher
@@ -161,15 +161,15 @@ These functions return nothing.
 .Sh EXAMPLES
 Hashing a message all at once:
 .Bd -literal -offset indent
-uint8_t hash   [ 64]; /* Output hash (64 bytes) */
-uint8_t message[500]; /* Message to hash        */
-crypto_sha512(hash, message, 500);
+uint8_t hash   [64]; /* Output hash (64 bytes)          */
+uint8_t message[12] = "Lorem ipsum"; /* Message to hash */
+crypto_sha512(hash, message, 12);
 .Ed
 .Pp
 Hashing a message incrementally:
 .Bd -literal -offset indent
 uint8_t hash   [ 64]; /* Output hash (64 bytes) */
-uint8_t message[500]; /* Message to hash        */
+uint8_t message[500] = {1}; /* Message to hash  */
 crypto_sha512_ctx ctx;
 crypto_sha512_init(&ctx);
 for (size_t i = 0; i < 500; i += 100) {


### PR DESCRIPTION
I'm just doing this to crypto_lock.3monocypher right now to see if this is an improvement.

While already there, I've taken a few other liberties for clarification (use `else` with `crypto_unlock` because there's not enough outer structure to suggest just `return -1` with no cleanup or `goto clean` so that it doesn't look like it's dangling into the decryption-good part anyway; there are contexts other than sending stuff over the network).

So far, I'm not really convinced of any of those changes though and do mildly believe that the status quo is better:

- The `random_bytes` introduction is kind of wordy and just triplicates the usual hint to generate randomness with the OS (once in the intro, once in the description for the `nonce` argument, once in the new paragraph).
- The additional context comments and `if`/`else` stuff is complex to understand—primarily because it is abstract. An abstract example is of only limited help, however, so I'm thinking maybe we'd be better off saying “we're assuming standard UNIX networking functions” and having a single example program talk to itself over a socketpair(2) with a random key, where the encryption part uses split buffers and the decryption part uses in-place decryption.