### PR TITLE
Document & test overlapping of key_exchange.

### DIFF
--- a/doc/man/man3/crypto_key_exchange.3monocypher
+++ b/doc/man/man3/crypto_key_exchange.3monocypher
@@ -101,6 +101,11 @@ Your public key, generated from
 with
 .Fn crypto_key_exchange_public_key .
 .El
+.Pp
+.Fa shared_key
+and
+.Fa your_secret_key
+may overlap if the secret is no longer required.
 .Sh RETURN VALUES
 .Fn crypto_key_exchange
 and

--- a/doc/man/man3/crypto_key_exchange.3monocypher
+++ b/doc/man/man3/crypto_key_exchange.3monocypher
@@ -11,6 +11,7 @@
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
 .\" Copyright (c) 2017, 2019 Fabio Scotoni
+.\" Copyright (c) 2020 Richard Walmsley
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +41,8 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage, Fabio Scotoni and
+.\" Richard Walmsley
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain

--- a/doc/man/man3/crypto_x25519.3monocypher
+++ b/doc/man/man3/crypto_x25519.3monocypher
@@ -11,6 +11,7 @@
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
 .\" Copyright (c) 2017, 2019 Fabio Scotoni
+.\" Copyright (c) 2020 Richard Walmsley
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +41,8 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2019 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2020 by Loup Vaillant, Michael Savage, Fabio Scotoni and
+.\" Richard Walmsley
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -106,6 +108,11 @@ for advice about generating random bytes (use the operating system's
 random number generator).
 .It Fa their_public_key
 The public key of the other party.
+.Pp
+.Fa raw_shared_secret
+and
+.Fa your_secret_key
+may overlap if your secret is no longer required.
 .El
 .Sh RETURN VALUES
 .Fn crypto_x25519

--- a/tests/test.c
+++ b/tests/test.c
@@ -9,7 +9,7 @@
 //
 // ------------------------------------------------------------------------
 //
-// Copyright (c) 2017-2019, Loup Vaillant
+// Copyright (c) 2017-2020, Loup Vaillant and Richard Walmsley
 // All rights reserved.
 //
 //
@@ -39,7 +39,7 @@
 //
 // ------------------------------------------------------------------------
 //
-// Written in 2017-2019 by Loup Vaillant
+// Written in 2017-2020 by Loup Vaillant and Richard Walmsley
 //
 // To the extent possible under law, the author(s) have dedicated all copyright
 // and related neighboring rights to this software to the public domain
@@ -660,17 +660,37 @@ static int p_argon2i_overlap()
     return status;
 }
 
+// Tests that the shared key and secret key buffers of crypto_x25519 can overlap.
+static int p_x25519_overlap()
+{
+    int status = 0;
+    FOR (i, 0, 62) {
+        u8 overlapping[94];
+        u8 seperate[32];
+        RANDOM_INPUT(sk, 32);
+        RANDOM_INPUT(pk, 32);
+        memcpy(overlapping + 31, sk, 32);
+        crypto_x25519(overlapping + i, overlapping + 31, pk);
+        crypto_x25519(seperate, sk, pk);
+        status |= memcmp(seperate, overlapping + i, 32);
+    }
+    printf("%s: x25519 (overlaping i/o)\n", status != 0 ? "FAILED" : "OK");
+    return status;
+}
+
 // Tests that the shared key and secret key buffers of crypto_key_exchange can overlap.
 static int p_key_exchange_overlap()
 {
     int status = 0;
-    FOR (i, 0, 5) {
-        u8 buf[32];
+    FOR (i, 0, 62) {
+        u8 overlapping[94];
+        u8 seperate[32];
         RANDOM_INPUT(sk, 32);
         RANDOM_INPUT(pk, 32);
-        crypto_key_exchange(buf, sk, pk);
-        crypto_key_exchange(sk, sk, pk);
-        status |= memcmp(buf, sk, 32);
+        memcpy(overlapping + 31, sk, 32);
+        crypto_key_exchange(overlapping + i, overlapping + 31, pk);
+        crypto_key_exchange(seperate, sk, pk);
+        status |= memcmp(seperate, overlapping + i, 32);
     }
     printf("%s: key_exchange (overlaping i/o)\n", status != 0 ? "FAILED" : "OK");
     return status;
@@ -869,6 +889,7 @@ int main(int argc, char *argv[])
     status |= p_hmac_sha512_overlap();
     status |= p_argon2i_easy();
     status |= p_argon2i_overlap();
+    status |= p_x25519_overlap();
     status |= p_key_exchange_overlap();
     status |= p_eddsa_roundtrip();
     status |= p_eddsa_random();

--- a/tests/test.c
+++ b/tests/test.c
@@ -660,6 +660,22 @@ static int p_argon2i_overlap()
     return status;
 }
 
+// Tests that the shared key and secret key buffers of crypto_key_exchange can overlap.
+static int p_key_exchange_overlap()
+{
+    int status = 0;
+    FOR (i, 0, 5) {
+        u8 buf[32];
+        RANDOM_INPUT(sk, 32);
+        RANDOM_INPUT(pk, 32);
+        crypto_key_exchange(buf, sk, pk);
+        crypto_key_exchange(sk, sk, pk);
+        status |= memcmp(buf, sk, 32);
+    }
+    printf("%s: key_exchange (overlaping i/o)\n", status != 0 ? "FAILED" : "OK");
+    return status;
+}
+
 static int p_eddsa_roundtrip()
 {
 #define MESSAGE_SIZE 30
@@ -853,6 +869,7 @@ int main(int argc, char *argv[])
     status |= p_hmac_sha512_overlap();
     status |= p_argon2i_easy();
     status |= p_argon2i_overlap();
+    status |= p_key_exchange_overlap();
     status |= p_eddsa_roundtrip();
     status |= p_eddsa_random();
     status |= p_eddsa_overlap();


### PR DESCRIPTION
As discussed with Loup via e-mail, document and create a test for overlapping the shared_key & your_secret_key buffers for crypto_key_exchange().

Useful as in my application, there's no reason to keep around the secret key after obtaining a shared key, avoiding locking and wiping an extra buffer.