### PR TITLE
Make tarball generation reproducible

### DIFF
--- a/tests/gen/elligator-direct.py
+++ b/tests/gen/elligator-direct.py
@@ -12,6 +12,7 @@
 # ------------------------------------------------------------------------
 #
 # Copyright (c) 2020, Loup Vaillant
+# Copyright (c) 2020, Fabio Scotoni
 # All rights reserved.
 #
 #
@@ -41,7 +42,7 @@
 #
 # ------------------------------------------------------------------------
 #
-# Written in 2020 by Loup Vaillant
+# Written in 2020 by Loup Vaillant and Fabio Scotoni
 #
 # To the extent possible under law, the author(s) have dedicated all copyright
 # and related neighboring rights to this software to the public domain
@@ -58,6 +59,7 @@ from elligator import fast_hash_to_curve
 from elligator import p
 from elligator import print_raw
 from random    import randrange
+from random    import seed
 
 def direct(r1, padding):
     q1 = hash_to_curve(r1)
@@ -73,5 +75,10 @@ direct(fe(0), 0) # representative 0 maps to point (0, 0)
 direct(fe(0), 1) # representative 0 maps to point (0, 0)
 direct(fe(0), 2) # representative 0 maps to point (0, 0)
 direct(fe(0), 3) # representative 0 maps to point (0, 0)
+
+# Make test vector generation deterministic, the actual randomness does
+# not matter here since these are just tests.
+seed(12345)
+
 for i in range(50):
     direct(fe(randrange(0, (p-1)/2)), i % 4)

--- a/tests/gen/elligator-inverse.py
+++ b/tests/gen/elligator-inverse.py
@@ -12,6 +12,7 @@
 # ------------------------------------------------------------------------
 #
 # Copyright (c) 2020, Loup Vaillant
+# Copyright (c) 2020, Fabio Scotoni
 # All rights reserved.
 #
 #
@@ -41,7 +42,7 @@
 #
 # ------------------------------------------------------------------------
 #
-# Written in 2020 by Loup Vaillant
+# Written in 2020 by Loup Vaillant and Fabio Scotoni
 #
 # To the extent possible under law, the author(s) have dedicated all copyright
 # and related neighboring rights to this software to the public domain
@@ -60,6 +61,7 @@ from elligator import print_raw
 from elligator_scalarmult import scalarmult
 
 from random import randrange
+from random import seed
 
 def private_to_curve_and_hash(scalar, tweak):
     cofactor      = scalar % 8
@@ -77,6 +79,10 @@ def private_to_curve_and_hash(scalar, tweak):
     u2, v2 = hash_to_curve(r1)
     if u2 != u: raise ValueError('Round trip failure')
     return (u, r1.val + msb)
+
+# Make test vector generation deterministic, the actual randomness does
+# not matter here since these are just tests.
+seed(12345)
 
 # All possible failures
 for cofactor in range(8):


### PR DESCRIPTION
There's a *lot* of other environmental damage that can't really be avoided, so reprodicibility depends on the exact setup used to generate the tarball anyway:

- at least OpenBSD sed(1) apparently munges the README *slightly* differently
- mandoc(1) versions *must not* differ or the HTML generated by doc2html will differ
- the operating system reported in mandoc(1) *must not* differ or the HTML generated by doc2html will differ
- probably more that I didn't catch after giving up at cross-OS reproducibility

So for anyone to be able to actually reproduce a release tarball, they need to know the exact setup. Perhaps building on a specific public Docker image and specifying this might be the easiest way to fixate and publicize this.