### PR TITLE
intro: macOS, illumos and Solaris have arc4random_buf(3)

### DIFF
--- a/doc/man/man3/intro.3monocypher
+++ b/doc/man/man3/intro.3monocypher
@@ -241,7 +241,7 @@ in
 .In linux/random.h .
 Do not set any flag.
 .It
-BSD provides
+BSD, Darwin/macOS, illumos as well as Solaris provide
 .Fn arc4random_buf
 in
 .In stdlib.h


### PR DESCRIPTION
Note that Solaris botched it in 11.3.9 and only made it good in 11.3.14. As far as I can tell, this has been long enough ago (more than two years at least, which matches FreeBSD fixing arc4random) that we can just put it in without reservation.

Note I've very intentionally overshot the requirements of #180. While macOS is probably the most relevant target (and hence earning Monocypher the questionable honor of being assigned a MON-01-001), this indicates that people scan for specific operating systems. While I've been operating under the assumption that programmers would know what their target OSes support, I figured we might as well take this chance to be very explicit about other, more niche operating systems, in hopes that people will test portability to more platforms.