### PR TITLE
HISTORY: note 2.0.5 rejecting modified signatures

### DIFF
--- a/doc/man/man3/advanced/crypto_sign_init_first_pass.3monocypher
+++ b/doc/man/man3/advanced/crypto_sign_init_first_pass.3monocypher
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd March 31, 2020
+.Dd September 26, 2020
 .Dt CRYPTO_SIGN_INIT_FIRST_PASS 3MONOCYPHER
 .Os
 .Sh NAME
@@ -270,6 +270,12 @@ The
 and
 .Fn crypto_check_final
 functions first appeared in Monocypher 1.1.0.
+.Pp
+Starting with Monocypher 2.0.5, modified signatures abusing the inherent
+signature malleability property of EdDSA now cause a non-zero return
+value of
+.Fn crypto_check_final ;
+in prior versions, such signatures would be accepted.
 .Pp
 .Sy A critical security vulnerability
 that caused all-zero signatures to be accepted was introduced in

--- a/doc/man/man3/crypto_sign.3monocypher
+++ b/doc/man/man3/crypto_sign.3monocypher
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd March 31, 2020
+.Dd September 26, 2020
 .Dt CRYPTO_SIGN 3MONOCYPHER
 .Os
 .Sh NAME
@@ -207,6 +207,12 @@ The
 and
 .Fn crypto_sign_public_key
 functions appeared in Monocypher 0.2.
+.Pp
+Starting with Monocypher 2.0.5, modified signatures abusing the inherent
+signature malleability property of EdDSA now cause a non-zero return
+value of
+.Fn crypto_check ;
+in prior versions, such signatures would be accepted.
 .Pp
 .Sy A critical security vulnerability
 that caused all-zero signatures to be accepted was introduced in


### PR DESCRIPTION
Did some dumpster diving to figure this out. In retrospect, I'm surprised there wasn't a major version spike after this, but it's not like signatures generated by abusing signature malleability ever happen with legitimate signers in the first place.

There doesn't seem to be a good term to refer to a signature that is valid but has a greater *S* value than *L* without dragging the whole explanation of EdDSA in.

---

Change introduced in 974e55d21c1fac7a2e21f91cb7174601b653180a and
24f4be7acc3ec7ff613715a7a97597e587f6d6d8.

The actual reasons to introduce this were actually performance-related.

Sparked by #189.