### PR TITLE
Add a preprocessor macro for removing blake2

### DIFF
--- a/src/monocypher.c
+++ b/src/monocypher.c
@@ -673,6 +673,7 @@ void crypto_blake2b_general(u8       *hash   , size_t hash_size,
     crypto_blake2b_final(&ctx, hash);
 }
 
+#ifndef REMOVE_BLAKE2
 void crypto_blake2b(u8 hash[64], const u8 *message, size_t message_size)
 {
     crypto_blake2b_general(hash, 64, 0, 0, message, message_size);
@@ -694,6 +695,7 @@ const crypto_sign_vtable crypto_blake2b_vtable = {
     blake2b_vtable_final,
     sizeof(crypto_sign_ctx),
 };
+#endif
 
 ////////////////
 /// Argon2 i ///


### PR DESCRIPTION
HIi,

I wanted to use monocypher as part of a signature check reference implementation, using ed25519 / sha512.

But with the latest monocypher master, I struggle in optimizing code size. In particular since the ctx/hash api works through function pointers, the linker is never unable to remove the large blake2 code (not even when including all the code into the same compilation unit)

This PR presents one possible way to remove this bloat, do you think that this is the right way to accomplish size optimization, and if something like this could be done also in master?

Thanks,
Jukka

-----------------------------

Add a pre-processor macro to remove BLAKE2 vtable.
This allows linker to remove all blake2 functionality when using
sha512 only, saving flash space

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>
