### PR TITLE
Canonicalize spellings of algorithms

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,7 +3,7 @@ Designers
 
 - **ChaCha20:** Daniel J. Bernstein.
 - **Poly1305:** Daniel J. Bernstein.
-- **Blake2:**   Jean-Philippe Aumasson, Christian Winnerlein, Samuel Neves,
+- **BLAKE2:**   Jean-Philippe Aumasson, Christian Winnerlein, Samuel Neves,
                 and Zooko Wilcox-O'Hearn
 - **Argon2:**   Alex Biryukov, Daniel Dinu, and Dmitry Khovratovich
 - **X25519:**   Daniel J. Bernstein
@@ -15,7 +15,7 @@ Implementors
 
 - **ChaCha20:** Loup Vaillant, implemented from spec.
 - **Poly1305:** Loup Vaillant, implemented from spec.
-- **Blake2b:**  Loup Vaillant, implemented from spec.
+- **BLAKE2b:**  Loup Vaillant, implemented from spec.
 - **Argon2i:**  Loup Vaillant, implemented from spec.
 - **X25519:**   Daniel J. Bernstein, taken and packaged from SUPERCOP
                 ref10.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,7 @@
 Designers
 ---------
 
-- **Chacha20:** Daniel J. Bernstein.
+- **ChaCha20:** Daniel J. Bernstein.
 - **Poly1305:** Daniel J. Bernstein.
 - **Blake2:**   Jean-Philippe Aumasson, Christian Winnerlein, Samuel Neves,
                 and Zooko Wilcox-O'Hearn
@@ -13,7 +13,7 @@ Designers
 Implementors
 ------------
 
-- **Chacha20:** Loup Vaillant, implemented from spec.
+- **ChaCha20:** Loup Vaillant, implemented from spec.
 - **Poly1305:** Loup Vaillant, implemented from spec.
 - **Blake2b:**  Loup Vaillant, implemented from spec.
 - **Argon2i:**  Loup Vaillant, implemented from spec.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Features
 
 - [Authenticated Encryption][AEAD] with XChaCha20 and Poly1305
   (RFC&nbsp;8439).
-- [Hashing][HASH] with Blake2b.
+- [Hashing][HASH] with BLAKE2b.
 - [Password Hashing][PWH] with Argon2i.
 - [Public Key Cryptography][PKC] with X25519 (key exchange).
 - [Public Key Signatures][PKS] with EdDSA (RFC 8032) and Ed25519.
@@ -206,7 +206,7 @@ is activated by compiling monocypher.c with the `-DBLAKE2_NO_UNROLLING`
 option.
 
 The `-DBLAKE2_NO_UNROLLING` option is a performance tweak.  By default,
-Monocypher unrolls the Blake2b inner loop, because doing so is over 25%
+Monocypher unrolls the BLAKE2b inner loop, because doing so is over 25%
 faster on modern processors.  Some embedded processors however, run the
 unrolled loop _slower_ (possibly because of the cost of fetching 5KB of
 additional code).  If you're using an embedded platform, try this

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ speed of [Libsodium][].
 Features
 --------
 
-- [Authenticated Encryption][AEAD] with XChacha20 and Poly1305
+- [Authenticated Encryption][AEAD] with XChaCha20 and Poly1305
   (RFC&nbsp;8439).
 - [Hashing][HASH] with Blake2b.
 - [Password Hashing][PWH] with Argon2i.

--- a/doc/man/man3/advanced/crypto_chacha20.3monocypher
+++ b/doc/man/man3/advanced/crypto_chacha20.3monocypher
@@ -357,7 +357,7 @@ that were deprecated in Monocypher 3.0.0.
 ChaCha20 only protects against eavesdropping, not forgeries.
 Most applications need protection against forgeries to be properly
 secure.
-To ensure the integrity of a message, use Blake2b in keyed mode, or
+To ensure the integrity of a message, use BLAKE2b in keyed mode, or
 authenticated encryption; see
 .Xr crypto_blake2b 3monocypher
 and

--- a/doc/man/man3/advanced/crypto_chacha20.3monocypher
+++ b/doc/man/man3/advanced/crypto_chacha20.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2018 Michael Savage
-.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2021 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2021 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd March 31, 2020
+.Dd June 11, 2021
 .Dt CRYPTO_CHACHA20 3MONOCYPHER
 .Os
 .Sh NAME
@@ -58,7 +58,7 @@
 .Nm crypto_chacha20_ctr ,
 .Nm crypto_xchacha20 ,
 .Nm crypto_xchacha20_ctr
-.Nd Chacha20 and XChacha20 encryption functions
+.Nd ChaCha20 and XChaCha20 encryption functions
 .Sh SYNOPSIS
 .In monocypher.h
 .Ft void
@@ -96,10 +96,10 @@
 .Fa "uint64_t ctr"
 .Fc
 .Sh DESCRIPTION
-These functions provide an interface for the Chacha20 encryption
+These functions provide an interface for the ChaCha20 encryption
 primitive.
 .Pp
-Chacha20 is a low-level primitive.
+ChaCha20 is a low-level primitive.
 Consider using authenticated encryption, implemented by
 .Xr crypto_lock 3monocypher .
 .Pp
@@ -127,7 +127,7 @@ It is allowed to be
 .Dv NULL ,
 in which case it will be interpreted as an all zero input.
 .Fa cipher_text
-will then contain the raw Chacha20 stream.
+will then contain the raw ChaCha20 stream.
 .It Fa cipher_text
 The encrypted message.
 .It Fa text_size
@@ -152,12 +152,12 @@ must either be the same buffer (for in-place encryption), or
 non-overlapping.
 .Pp
 .Fn crypto_chacha20
-performs a Chacha20 operation.
+performs a ChaCha20 operation.
 It uses an 8-byte nonce, which is too small to be selected at random.
 Use a message counter as a nonce instead.
 .Pp
 .Fn crypto_xchacha20
-performs an XChacha20 operation.
+performs an XChaCha20 operation.
 It uses a 24-byte nonce, which is large enough to be selected at random.
 .Pp
 .Fn crypto_xchacha20
@@ -211,7 +211,7 @@ The
 .Fn crypto_chacha20_ctr
 and
 .Fn crypto_xchacha20_ctr
-perform a Chacha20 or XChacha20 encryption, respectively,
+perform a ChaCha20 or XChaCha20 encryption, respectively,
 starting the stream at the block
 .Fa ctr
 (which is the byte
@@ -325,8 +325,8 @@ crypto_wipe(plain_text, 500);
 .Xr crypto_wipe 3monocypher ,
 .Xr intro 3monocypher
 .Sh STANDARDS
-These functions implement Chacha20 and XChacha20.
-Chacha20 is described in:
+These functions implement ChaCha20 and XChaCha20.
+ChaCha20 is described in:
 .Rs
 .%A Daniel J. Bernstein
 .%J SASC 2008 \(en The State of the Art of Stream Ciphers
@@ -334,9 +334,9 @@ Chacha20 is described in:
 .%T ChaCha, a variant of Salsa20
 .Re
 The nonce and counter sizes were modified in RFC 8439.
-XChacha20 derives from Chacha20 the same way XSalsa20 derives from
+XChaCha20 derives from ChaCha20 the same way XSalsa20 derives from
 Salsa20, and benefits from the same security reduction (proven secure
-as long as Chacha20 itself is secure).
+as long as ChaCha20 itself is secure).
 .Sh HISTORY
 .Fn crypto_chacha20 ,
 .Fn crypto_chacha20_ctr ,
@@ -354,7 +354,7 @@ and
 that were deprecated in Monocypher 3.0.0.
 .Sh SECURITY CONSIDERATIONS
 .Ss Encrypted does not mean secure
-Chacha20 only protects against eavesdropping, not forgeries.
+ChaCha20 only protects against eavesdropping, not forgeries.
 Most applications need protection against forgeries to be properly
 secure.
 To ensure the integrity of a message, use Blake2b in keyed mode, or
@@ -387,5 +387,5 @@ Secrets should not dwell in memory longer than needed.
 Use
 .Xr crypto_wipe 3monocypher
 to erase secrets you no longer need.
-For Chacha20, this means the key and in some cases the
+For ChaCha20, this means the key and in some cases the
 plain text itself.

--- a/doc/man/man3/advanced/crypto_hchacha20.3monocypher
+++ b/doc/man/man3/advanced/crypto_hchacha20.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2019-2020 Fabio Scotoni
+.\" Copyright (c) 2019-2021 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2021 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,12 +50,12 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd March 2, 2020
+.Dd June 11, 2021
 .Dt CRYPTO_HCHACHA20 3MONOCYPHER
 .Os
 .Sh NAME
 .Nm crypto_hchacha20
-.Nd HChacha20 special-purpose hashing
+.Nd HChaCha20 special-purpose hashing
 .Sh SYNOPSIS
 .In monocypher.h
 .Ft void
@@ -68,7 +68,7 @@
 .Fn crypto_hchacha20
 provides a not-so-cryptographic hash.
 It may be used for some specific purposes, such as X25519 key
-derivation, or XChacha20 initialisation.
+derivation, or XChaCha20 initialisation.
 If in doubt, do not use directly.
 Use
 .Xr crypto_blake2b 3monocypher
@@ -80,7 +80,7 @@ The arguments are:
 A sufficiently random key, such as the output of
 .Xr crypto_x25519 3monocypher .
 .It Fa in
-The space reserved for the Chacha20 nonce and counter.
+The space reserved for the ChaCha20 nonce and counter.
 It does not have to be random.
 .It Fa out
 A cryptographically secure random number
@@ -117,8 +117,8 @@ crypto_wipe(in , 16);
 .Xr crypto_key_exchange 3monocypher ,
 .Xr intro 3monocypher
 .Sh STANDARDS
-This function implements HChacha20.
-HChacha20 derives from Chacha20 the same way HSalsa20 derives from
+This function implements HChaCha20.
+HChaCha20 derives from ChaCha20 the same way HSalsa20 derives from
 Salsa20.
 .Sh HISTORY
 The

--- a/doc/man/man3/advanced/crypto_ietf_chacha20.3monocypher
+++ b/doc/man/man3/advanced/crypto_ietf_chacha20.3monocypher
@@ -8,7 +8,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Copyright (c) 2019-2020 Fabio Scotoni
+.\" Copyright (c) 2019-2021 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -38,7 +38,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2019-2020 by Fabio Scotoni
+.\" Written in 2019-2021 by Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -48,13 +48,13 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd March 31, 2020
+.Dd June 11, 2021
 .Dt CRYPTO_IETF_CHACHA20 3MONOCYPHER
 .Os
 .Sh NAME
 .Nm crypto_ietf_chacha20 ,
 .Nm crypto_ietf_chacha20_ctr
-.Nd IETF Chacha20 encryption functions
+.Nd IETF ChaCha20 encryption functions
 .Sh SYNOPSIS
 .In monocypher.h
 .Ft void
@@ -75,7 +75,7 @@
 .Fa "const uint32_t ctr"
 .Fc
 .Sh DESCRIPTION
-These functions provide an interface for the Chacha20 encryption
+These functions provide an interface for the ChaCha20 encryption
 primitive as specified by the IETF in RFC 8439.
 They are provided strictly for compatibility with existing systems
 or strict standards compliance.
@@ -83,7 +83,7 @@ New programs are strongly encouraged to use
 .Xr crypto_xchacha20 3monocypher
 instead.
 .Pp
-Chacha20 is a low-level primitive.
+ChaCha20 is a low-level primitive.
 Consider using authenticated encryption, implemented by
 .Xr crypto_lock 3monocypher .
 .Pp
@@ -124,7 +124,7 @@ plus one if there was a remainder.
 .Xr crypto_wipe 3monocypher ,
 .Xr intro 3monocypher
 .Sh STANDARDS
-These functions implement Chacha20 as described in RFC 8439.
+These functions implement ChaCha20 as described in RFC 8439.
 .Sh HISTORY
 .Fn crypto_ietf_chacha20
 and

--- a/doc/man/man3/advanced/crypto_poly1305.3monocypher
+++ b/doc/man/man3/advanced/crypto_poly1305.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2017-2020 Fabio Scotoni
+.\" Copyright (c) 2017-2021 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2021 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd March 31, 2020
+.Dd June 11, 2021
 .Dt CRYPTO_POLY1305 3MONOCYPHER
 .Os
 .Sh NAME
@@ -215,7 +215,7 @@ Use authenticated encryption instead; see
 .Xr crypto_lock 3monocypher .
 If you are certain you do not want encryption, refer to
 .Xr crypto_blake2b 3monocypher
-on how to use Blake2b to generate message authentication codes.
+on how to use BLAKE2b to generate message authentication codes.
 .Ss Authentication key requirements
 Poly1305 is a
 .Em one-time

--- a/doc/man/man3/advanced/crypto_sign_init_first_pass.3monocypher
+++ b/doc/man/man3/advanced/crypto_sign_init_first_pass.3monocypher
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd May 25, 2021
+.Dd June 11, 2021
 .Dt CRYPTO_SIGN_INIT_FIRST_PASS 3MONOCYPHER
 .Os
 .Sh NAME
@@ -218,14 +218,14 @@ analysis and fault injection (glitching) \(en both of which require
 physical access and appropriate equipment.
 We inject additional randomness (at least 32 bytes) and
 enough all-zero padding to fill the hash function's block size
-(128 bytes for both Blake2b and SHA-512).
+(128 bytes for both BLAKE2b and SHA-512).
 Note that
 .Fn crypto_sign_init_first_pass
 already fills 32 bytes,
 so randomness and padding must fill 32 bytes
 .Em less
 than the block
-size (96 bytes for Blake2b and SHA-512).
+size (96 bytes for BLAKE2b and SHA-512).
 Access to a cryptographically secure pseudo-random generator is a
 requirement for effective side channel mitigation.
 Signing a message with increased power-related side channel mitigations:
@@ -264,9 +264,9 @@ crypto_wipe(sk,  32);
 .Xr crypto_wipe 3monocypher ,
 .Xr intro 3monocypher
 .Sh STANDARDS
-These functions implement PureEdDSA with Curve25519 and Blake2b, as
+These functions implement PureEdDSA with Curve25519 and BLAKE2b, as
 described in RFC 8032.
-This is the same as Ed25519, with Blake2b instead of SHA-512.
+This is the same as Ed25519, with BLAKE2b instead of SHA-512.
 .Pp
 The example for side channel mitigation follows the methodology outlined
 in I-D.draft-mattsson-cfrg-det-sigs-with-noise-02.

--- a/doc/man/man3/crypto_blake2b.3monocypher
+++ b/doc/man/man3/crypto_blake2b.3monocypher
@@ -123,9 +123,9 @@ Length of
 .Fa hash ,
 in bytes.
 Must be between 1 and 64.
-Anything below 32 is discouraged when using Blake2b as a general-purpose
+Anything below 32 is discouraged when using BLAKE2b as a general-purpose
 hash function;
-anything below 16 is discouraged when using Blake2b as a message
+anything below 16 is discouraged when using BLAKE2b as a message
 authentication code.
 .It Fa key
 Some secret key.

--- a/doc/man/man3/crypto_blake2b.3monocypher
+++ b/doc/man/man3/crypto_blake2b.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2018 Michael Savage
-.\" Copyright (c) 2017, 2020 Fabio Scotoni
+.\" Copyright (c) 2017, 2020-2021 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2021 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd March 31, 2020
+.Dd June 11, 2021
 .Dt CRYPTO_BLAKE2B 3MONOCYPHER
 .Os
 .Sh NAME
@@ -102,7 +102,7 @@
 .Fc
 .Sh DESCRIPTION
 BLAKE2b is a fast cryptographically secure hash, based on the ideas of
-Chacha20.
+ChaCha20.
 It is faster than MD5, yet just as secure as SHA-3.
 .Pp
 Note that BLAKE2b itself is not suitable for hashing passwords and

--- a/doc/man/man3/crypto_key_exchange.3monocypher
+++ b/doc/man/man3/crypto_key_exchange.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2021 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2021 Fabio Scotoni
 .\" Copyright (c) 2020 Richard Walmsley
 .\" All rights reserved.
 .\"
@@ -52,7 +52,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd June 6, 2021
+.Dd June 11, 2021
 .Dt CRYPTO_KEY_EXCHANGE 3MONOCYPHER
 .Os
 .Sh NAME
@@ -166,7 +166,7 @@ crypto_wipe(your_sk, 32);
 .Sh STANDARDS
 These functions implement X25519, described in RFC 7748.
 .Fn crypto_key_exchange
-uses HChacha20 as well.
+uses HChaCha20 as well.
 .Sh HISTORY
 The
 .Fn crypto_key_exchange

--- a/doc/man/man3/crypto_lock.3monocypher
+++ b/doc/man/man3/crypto_lock.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2021 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2021 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd February 29, 2020
+.Dd June 11, 2021
 .Dt CRYPTO_LOCK 3MONOCYPHER
 .Os
 .Sh NAME
@@ -315,10 +315,10 @@ if (crypto_unlock(text, key, nonce, mac, text, 12)) {
 .Xr crypto_wipe 3monocypher ,
 .Xr intro 3monocypher
 .Sh STANDARDS
-These functions implement RFC 8439, with XChacha20 instead of Chacha20.
-XChacha20 derives from Chacha20 the same way XSalsa20 derives from
+These functions implement RFC 8439, with XChaCha20 instead of ChaCha20.
+XChaCha20 derives from ChaCha20 the same way XSalsa20 derives from
 Salsa20, and benefits from the same security reduction (proven secure
-as long as Chacha20 itself is secure).
+as long as ChaCha20 itself is secure).
 .Sh HISTORY
 The
 .Fn crypto_lock
@@ -330,9 +330,9 @@ and
 .Fn crypto_unlock_aead
 were introduced in Monocypher 1.1.0.
 In Monocypher 2.0.0, the underlying algorithms for these functions were
-changed from a custom XChacha20/Poly1305 construction to an
-implementation of RFC 7539 (now RFC 8439) with XChacha20 instead of
-Chacha20.
+changed from a custom XChaCha20/Poly1305 construction to an
+implementation of RFC 7539 (now RFC 8439) with XChaCha20 instead of
+ChaCha20.
 The
 .Fn crypto_lock_encrypt
 and

--- a/doc/man/man3/crypto_sign.3monocypher
+++ b/doc/man/man3/crypto_sign.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2021 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -40,7 +40,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2017-2020 by Loup Vaillant, Michael Savage and Fabio Scotoni
+.\" Written in 2017-2021 by Loup Vaillant, Michael Savage and Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd September 26, 2020
+.Dd June 11, 2021
 .Dt CRYPTO_SIGN 3MONOCYPHER
 .Os
 .Sh NAME
@@ -197,9 +197,9 @@ if (crypto_check(signature, pk, message, 10)) {
 .Xr crypto_lock 3monocypher ,
 .Xr intro 3monocypher
 .Sh STANDARDS
-These functions implement PureEdDSA with Curve25519 and Blake2b, as
+These functions implement PureEdDSA with Curve25519 and BLAKE2b, as
 described in RFC 8032.
-This is the same as Ed25519, with Blake2b instead of SHA-512.
+This is the same as Ed25519, with BLAKE2b instead of SHA-512.
 .Sh HISTORY
 The
 .Fn crypto_sign ,

--- a/doc/man/man3/deprecated/crypto_chacha20_encrypt.3monocypher
+++ b/doc/man/man3/deprecated/crypto_chacha20_encrypt.3monocypher
@@ -8,7 +8,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Copyright (c) 2019 Fabio Scotoni
+.\" Copyright (c) 2019, 2021 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -38,7 +38,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2019 by Fabio Scotoni
+.\" Written in 2019 and 2021 by Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -48,7 +48,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd December 2, 2019
+.Dd June 11, 2021
 .Dt CRYPTO_CHACHA20_ENCRYPT 3MONOCYPHER
 .Os
 .Sh NAME
@@ -57,7 +57,7 @@
 .Nm crypto_chacha20_x_init ,
 .Nm crypto_chacha20_stream ,
 .Nm crypto_chacha20_set_ctr
-.Nd deprecated Chacha20 and XChacha20 encryption functions
+.Nd deprecated ChaCha20 and XChaCha20 encryption functions
 .Sh SYNOPSIS
 .In monocypher.h
 .Ft void
@@ -91,7 +91,7 @@
 .Fa "uint64_t ctr"
 .Fc
 .Sh DESCRIPTION
-These functions provided an incremental interface for the Chacha20
+These functions provided an incremental interface for the ChaCha20
 cipher.
 They are deprecated in favor of
 .Xr crypto_chacha20 3monocypher ,
@@ -111,14 +111,14 @@ The new functions
 This means that input ciphertexts or plaintexts
 whose lengths are not exactly multiples of 64 bytes
 advance the counter, even though there is theoretically some space left
-in a Chacha20 block.
+in a ChaCha20 block.
 New applications should design their code so that either
 the protocl is not reliant on the counter covering the entire text
 (e.g. by cutting input into independent chunks) or
 inputs are always such that their lengths are multiples of 64 bytes
 (e.g. by buffering input until 64 bytes have been obtained).
 .Pp
-To obtain the raw Chacha20 stream previously provided by
+To obtain the raw ChaCha20 stream previously provided by
 .Fn crypto_chacha20_stream ,
 pass
 .Dv NULL

--- a/doc/man/man3/intro.3monocypher
+++ b/doc/man/man3/intro.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2021 Loup Vaillant
 .\" Copyright (c) 2018 Michael Savage
-.\" Copyright (c) 2017, 2019-2020 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2021 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd June 6, 2021
+.Dd June 11, 2021
 .Dt INTRO 3MONOCYPHER
 .Os
 .Sh NAME
@@ -64,9 +64,9 @@ hashing and key derivation, key exchange, and public key signatures.
 .Xr crypto_lock 3monocypher
 and
 .Xr crypto_unlock 3monocypher
-use the Chacha20 cipher and the Poly1305 one-time authenticator.
+use the ChaCha20 cipher and the Poly1305 one-time authenticator.
 .Pp
-Chacha20 is a stream cipher based on a cryptographic hash function.
+ChaCha20 is a stream cipher based on a cryptographic hash function.
 It runs efficiently on a wide variety of hardware, and unlike AES
 naturally runs in constant time on all hardware.
 .Pp

--- a/doc/man/man3/intro.3monocypher
+++ b/doc/man/man3/intro.3monocypher
@@ -84,8 +84,8 @@ Whenever possible,
 should be preferred, however.
 .Ss Hashing
 .Xr crypto_blake2b 3monocypher
-implements the Blake2b hash.
-Blake2b combines the security of SHA-3 and the speed of MD5.
+implements the BLAKE2b hash.
+BLAKE2b combines the security of SHA-3 and the speed of MD5.
 It is immune to length extension attacks and provides a keyed mode
 that makes it a safe, easy to use authenticator.
 .Ss Password hashing and key derivation
@@ -111,9 +111,9 @@ as random noise.
 .Xr crypto_sign 3monocypher
 and
 .Xr crypto_check 3monocypher
-implement EdDSA, with Curve25519 and Blake2b.
+implement EdDSA, with Curve25519 and BLAKE2b.
 This is the same as the more famous Ed25519, with SHA-512 replaced by
-the faster and more secure Blake2b.
+the faster and more secure BLAKE2b.
 .Pp
 For highly specialised needs,
 it is possible to use a custom hash function with EdDSA;


### PR DESCRIPTION
Inspired by [this tweet by Jean-Philippe Aumasson](https://twitter.com/veorq/status/1396728032883322884). I believe it makes a positive impression to actually spell names correctly.

I didn't touch the code mainly for reasons of not intruding upon @LoupVaillant's territory, but it may be reasonable to also adjust comments and text case output as well.