### PR TITLE
Allow API to be put in a C++ namespace

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -55,3 +55,7 @@ Mike Hamburg explained comb algorithms, including the signed
 all-bits-set comb described in his 2012 paper, Fast and compact
 elliptic-curve cryptography.  This made EdDSA signatures over twice as
 fast.
+
+Jens Alfke added some #ifdefs that enabled Monocypher to compile into
+a C++ namespace, preventing symbol collisions with similarly-named
+functions in other crypto libraries.

--- a/src/deprecated/aead-incr.c
+++ b/src/deprecated/aead-incr.c
@@ -87,6 +87,10 @@
 
 #include "aead-incr.h"
 
+#ifdef MONOCYPHER_CPP_NAMESPACE
+namespace MONOCYPHER_CPP_NAMESPACE {
+#endif
+
 #define FOR_T(type, i, start, end) for (type i = (start); i < (end); i++)
 #define FOR(i, start, end)         FOR_T(size_t, i, start, end)
 #define WIPE_CTX(ctx)              crypto_wipe(ctx   , sizeof(*(ctx)))
@@ -227,3 +231,7 @@ int crypto_unlock_final(crypto_lock_ctx *ctx, const u8 mac[16])
     WIPE_BUFFER(real_mac);
     return mismatch;
 }
+
+#ifdef MONOCYPHER_CPP_NAMESPACE
+}
+#endif

--- a/src/deprecated/aead-incr.h
+++ b/src/deprecated/aead-incr.h
@@ -92,7 +92,9 @@
 #include <inttypes.h>
 #include "monocypher.h"
 
-#ifdef __cplusplus
+#ifdef MONOCYPHER_CPP_NAMESPACE
+namespace MONOCYPHER_CPP_NAMESPACE {
+#elif defined(__cplusplus)
 extern "C" {
 #endif
 

--- a/src/deprecated/chacha20.c
+++ b/src/deprecated/chacha20.c
@@ -79,6 +79,10 @@
 #include "chacha20.h"
 #include "monocypher.h"
 
+#ifdef MONOCYPHER_CPP_NAMESPACE
+namespace MONOCYPHER_CPP_NAMESPACE {
+#endif
+
 #define FOR_T(type, i, start, end) for (type i = (start); i < (end); i++)
 #define FOR(i, start, end)         FOR_T(size_t, i, start, end)
 #define WIPE_CTX(ctx)              crypto_wipe(ctx   , sizeof(*(ctx)))
@@ -146,3 +150,7 @@ void crypto_chacha20_stream(crypto_chacha_ctx *ctx, u8 *stream, size_t size)
 {
     crypto_chacha20_encrypt(ctx, stream, 0, size);
 }
+
+#ifdef MONOCYPHER_CPP_NAMESPACE
+}
+#endif

--- a/src/deprecated/chacha20.h
+++ b/src/deprecated/chacha20.h
@@ -82,7 +82,9 @@
 #include <stddef.h>
 #include <inttypes.h>
 
-#ifdef __cplusplus
+#ifdef MONOCYPHER_CPP_NAMESPACE
+namespace MONOCYPHER_CPP_NAMESPACE {
+#elif defined(__cplusplus)
 extern "C" {
 #endif
 

--- a/src/monocypher.c
+++ b/src/monocypher.c
@@ -53,6 +53,10 @@
 
 #include "monocypher.h"
 
+#ifdef MONOCYPHER_CPP_NAMESPACE
+namespace MONOCYPHER_CPP_NAMESPACE {
+#endif
+
 /////////////////
 /// Utilities ///
 /////////////////
@@ -2957,3 +2961,7 @@ int crypto_unlock(u8 *plain_text,
     return crypto_unlock_aead(plain_text, key, nonce, mac, 0, 0,
                               cipher_text, text_size);
 }
+
+#ifdef MONOCYPHER_CPP_NAMESPACE
+}
+#endif

--- a/src/monocypher.h
+++ b/src/monocypher.h
@@ -57,7 +57,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#ifdef __cplusplus
+#ifdef MONOCYPHER_CPP_NAMESPACE
+namespace MONOCYPHER_CPP_NAMESPACE {
+#elif defined(__cplusplus)
 extern "C" {
 #endif
 

--- a/src/optional/monocypher-ed25519.c
+++ b/src/optional/monocypher-ed25519.c
@@ -53,6 +53,10 @@
 
 #include "monocypher-ed25519.h"
 
+#ifdef MONOCYPHER_CPP_NAMESPACE
+namespace MONOCYPHER_CPP_NAMESPACE {
+#endif
+
 /////////////////
 /// Utilities ///
 /////////////////
@@ -407,3 +411,7 @@ void crypto_from_ed25519_private(u8 x25519[32], const u8 eddsa[32])
     COPY(x25519, a, 32);
     WIPE_BUFFER(a);
 }
+
+#ifdef MONOCYPHER_CPP_NAMESPACE
+}
+#endif

--- a/src/optional/monocypher-ed25519.h
+++ b/src/optional/monocypher-ed25519.h
@@ -56,7 +56,9 @@
 
 #include "monocypher.h"
 
-#ifdef __cplusplus
+#ifdef MONOCYPHER_CPP_NAMESPACE
+namespace MONOCYPHER_CPP_NAMESPACE {
+#elif defined(__cplusplus)
 extern "C" {
 #endif
 


### PR DESCRIPTION
Minimal change to permit Monocypher to be compiled as C++ and wrapped in a namespace, to prevent symbol name collisions (#224). I have verified that this works, in [a branch of my monocypher-cpp project](https://github.com/snej/monocypher-cpp/commit/adae8d327f16760c8feab6838f1999ea07409ea6).

If the preprocessor symbol `MONOCYPHER_CPP_NAMESPACE` is defined, the Monocypher headers will be wrapped in a C++ namespace instead of in `extern "C"`. The name of the namespace is the value of the symbol.

Using this feature requires also compiling monocypher.c as C++ in the same namespace, for instance by using a C++ source file wrapping the C one:

```
// monocypher.cpp
#define MONOCYPHER_CPP_NAMESPACE monocypher
namespace MONOCYPHER_CPP_NAMESPACE {
#  include "monocypher.c"
}
```

(Such a source file could be added here as `monocypher.cpp`, but I was going for the minimal-size change.)