### PR TITLE
crypto_sign doc hotfix: Miscellaneous improvements

### DIFF
--- a/doc/man/man3/crypto_sign.3monocypher
+++ b/doc/man/man3/crypto_sign.3monocypher
@@ -201,7 +201,7 @@ if (crypto_check(signature, pk, message, 10)) {
 .Pp
 To avoid recomputing the public key with each signature,
 store it next to the private key
-.Pq Dq fat private key .
+.Pq Dq composite private key .
 Make sure you treat that key pair as a single unit:
 .Bd -literal -offset indent
 uint8_t sk[64];                       /* Fat secret key  */
@@ -213,7 +213,7 @@ memcmp(pk, sk + 32);                  /* Copy public key */
 crypto_wipe(sk, 64);
 .Ed
 .Pp
-That way signing can use the fat private key alone:
+That way signing can use the composite private key alone:
 .Bd -literal -offset indent
 uint8_t       sk       [64]; /* Fat secret key from above      */
 const uint8_t message  [11] = "Lorem ipsu"; /* Message to sign */
@@ -266,11 +266,11 @@ This method is slower,
 but in practice is often fast enough.
 .Pp
 The fastest is to treat the private and public key as a single unit:
-once generated, they must be stored together and treated as one fat
-private key.
+once generated, they must be stored together and treated
+as one composite private key.
 When calling
 .Fn crypto_sign ,
-provide the public half of the fat private key.
+provide the public half of the composite private key.
 The public half can be copied and and published separately,
 but the copy itself must never be used for signatures.
 .Ss Signature malleability

--- a/doc/man/man3/crypto_sign.3monocypher
+++ b/doc/man/man3/crypto_sign.3monocypher
@@ -125,9 +125,11 @@ signs a message with
 The public key is optional and will be recomputed if not provided.
 This recomputation doubles the execution time.
 .Sy Never sign a message with the wrong public key .
-It would expose the private key.
+Doing so would expose the private key.
 Either provide
 .Dv NULL
+as the
+.Fa public_key
 or store the private and public keys together as a single unit.
 .Pp
 .Fn crypto_check
@@ -197,8 +199,9 @@ if (crypto_check(signature, pk, message, 10)) {
 }
 .Ed
 .Pp
-To avoid recomputing the public key at each signature,
-we can store it next to the private key.
+To avoid recomputing the public key with each signature,
+store it next to the private key
+.Pq Dq fat private key .
 Make sure you treat that key pair as a single unit:
 .Bd -literal -offset indent
 uint8_t sk[64];                       /* Fat secret key  */
@@ -248,9 +251,9 @@ Monocypher 0.3;
 it was fixed in Monocypher 1.1.1 and 2.0.4.
 .Sh SECURITY CONSIDERATIONS
 .Ss Using the wrong public key exposes the private key
-Performing two signatures on the same message,
-with the same private key,
-but with two different public keys,
+Performing two signatures on the same message
+with the same private key
+but with two different public keys
 instantly exposes the private key.
 .Pp
 There are two ways to avoid this error.
@@ -263,11 +266,11 @@ This method is slower,
 but in practice is often fast enough.
 .Pp
 The fastest is to treat the private and public key as a single unit:
-once generated they must be stored together and treated as one fat
+once generated, they must be stored together and treated as one fat
 private key.
 When calling
 .Fn crypto_sign ,
-we give it the public half of that fat private key.
+provide the public half of the fat private key.
 The public half can be copied and and published separately,
 but the copy itself must never be used for signatures.
 .Ss Signature malleability

--- a/doc/man/man3/crypto_sign.3monocypher
+++ b/doc/man/man3/crypto_sign.3monocypher
@@ -208,7 +208,7 @@ uint8_t sk[64];                       /* Fat secret key  */
 uint8_t pk[32];                       /* Public key      */
 arc4random_buf(sk, 32);               /* Secret half     */
 crypto_sign_public_key(sk + 32, sk);  /* Public half     */
-memcmp(pk, sk + 32);                  /* Copy public key */
+memcpy(pk, sk + 32, 32);              /* Copy public key */
 /* Wipe the secret key if it is no longer needed */
 crypto_wipe(sk, 64);
 .Ed

--- a/doc/man/man3/crypto_sign.3monocypher
+++ b/doc/man/man3/crypto_sign.3monocypher
@@ -8,7 +8,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Copyright (c) 2017-2019 Loup Vaillant
+.\" Copyright (c) 2017-2019, 2022 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
 .\" Copyright (c) 2017, 2019-2022 Fabio Scotoni
 .\" All rights reserved.
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd February 13, 2022
+.Dd July 9, 2022
 .Dt CRYPTO_SIGN 3MONOCYPHER
 .Os
 .Sh NAME


### PR DESCRIPTION
You might disagree with some of the commits here, so I've split them up into logical units.

In re #240 pending the new `crypto_sign_safe()` and subsequent move to `advanced/` + deprecation warning.