### PR TITLE
Simplify crypto_verify

### DIFF
--- a/doc/man/man3/advanced/crypto_poly1305.3monocypher
+++ b/doc/man/man3/advanced/crypto_poly1305.3monocypher
@@ -122,7 +122,7 @@ in bytes.
 produces a message authentication code for the given message and
 authentication key.
 To verify the integrity of a message, use
-.Xr crypto_verify16 3monocypher
+.Xr crypto_verify 3monocypher
 to compare the received MAC to the output
 .Fa mac .
 .Ss Incremental interface
@@ -168,7 +168,7 @@ uint8_t       real_mac[16];           /* The actual MAC    */
 crypto_poly1305(real_mac, msg, 5, key);
 /* Wipe the key */
 crypto_wipe(key, 32);
-if (crypto_verify16(mac, real_mac)) {
+if (crypto_verify(mac, real_mac, 16)) {
     /* Corrupted message, abort processing */
 } else {
     /* Genuine message */
@@ -195,7 +195,7 @@ crypto_poly1305_final(&ctx, mac);
 .Sh SEE ALSO
 .Xr crypto_blake2b 3monocypher ,
 .Xr crypto_lock 3monocypher ,
-.Xr crypto_verify16 3monocypher ,
+.Xr crypto_verify 3monocypher ,
 .Xr intro 3monocypher
 .Sh STANDARDS
 These functions implement Poly1305, described in RFC 8439.
@@ -259,7 +259,7 @@ This is the approach used by
 .Xr crypto_lock_aead 3monocypher .
 .Ss Protection against side channels
 Use
-.Xr crypto_verify16 3monocypher
+.Xr crypto_verify 3monocypher
 to compare message authentication codes.
 Avoid standard buffer comparison functions:
 they may not run in constant time, enabling an attacker to exploit timing

--- a/doc/man/man3/crypto_argon2i.3monocypher
+++ b/doc/man/man3/crypto_argon2i.3monocypher
@@ -120,9 +120,6 @@ the output value.
 Length of
 .Fa hash ,
 in bytes.
-This argument should be set to 32 or 64 for compatibility with the
-.Fn crypto_verify*
-constant time comparison functions.
 .It Fa work_area
 Temporary buffer for the algorithm, allocated by the caller.
 It must be
@@ -176,10 +173,7 @@ Must be at least 8.
 The arguments may overlap or point at the same buffer.
 .Pp
 Use
-.Xr crypto_verify16 3monocypher ,
-.Xr crypto_verify32 3monocypher ,
-or
-.Xr crypto_verify64 3monocypher
+.Xr crypto_verify 3monocypher
 to compare password hashes to prevent timing attacks.
 .Pp
 To select the
@@ -284,7 +278,7 @@ if (work_area == NULL) {
 .Ed
 .Sh SEE ALSO
 .Xr crypto_lock 3monocypher ,
-.Xr crypto_verify16 3monocypher ,
+.Xr crypto_verify 3monocypher ,
 .Xr crypto_wipe 3monocypher ,
 .Xr intro 3monocypher
 .Sh STANDARDS

--- a/doc/man/man3/crypto_blake2b.3monocypher
+++ b/doc/man/man3/crypto_blake2b.3monocypher
@@ -137,10 +137,7 @@ if
 is 0, in which case no key is used.
 Keys can be used to create a message authentication code (MAC).
 Use
-.Xr crypto_verify16 3monocypher ,
-.Xr crypto_verify32 3monocypher ,
-or
-.Xr crypto_verify64 3monocypher
+.Xr crypto_verify 3monocypher
 to compare MACs created this way.
 Choose the size of the hash accordingly.
 Users may want to wipe the key with

--- a/doc/man/man3/crypto_verify.3monocypher
+++ b/doc/man/man3/crypto_verify.3monocypher
@@ -54,26 +54,15 @@
 .Dt CRYPTO_VERIFY16 3MONOCYPHER
 .Os
 .Sh NAME
-.Nm crypto_verify16 ,
-.Nm crypto_verify32 ,
-.Nm crypto_verify64
+.Nm crypto_verify
 .Nd timing-safe data comparison
 .Sh SYNOPSIS
 .In monocypher.h
 .Ft int
-.Fo crypto_verify16
+.Fo crypto_verify
 .Fa "const uint8_t a[16]"
 .Fa "const uint8_t b[16]"
-.Fc
-.Ft int
-.Fo crypto_verify32
-.Fa "const uint8_t a[32]"
-.Fa "const uint8_t b[32]"
-.Fc
-.Ft int
-.Fo crypto_verify64
-.Fa "const uint8_t a[64]"
-.Fa "const uint8_t b[64]"
+.Fa "size_t size"
 .Fc
 .Sh DESCRIPTION
 Cryptographic operations often require comparison of secrets or values
@@ -94,31 +83,25 @@ and successfully forge a message.
 This has led to practical attacks in the past.
 .Pp
 To avoid such catastrophic failure,
-.Fn crypto_verify16 ,
-.Fn crypto_verify32 ,
-and
-.Fn crypto_verify64
-provide comparison functions whose timing is independent from
-the content of their input.
-They compare the first
-16, 32, or 64 bytes of the two byte arrays
-.Fa a
-and
-.Fa b .
+.Fn crypto_verify,
+provides a comparison function whose timing is independent from
+the content of its input.
 .Pp
 When in doubt, prefer these functions over
 .Fn memcmp .
 .Sh RETURN VALUES
-These functions return 0 if the two memory chunks are the same and -1
+This function return 0 if the two memory chunks are the same and -1
 otherwise.
 .Sh SEE ALSO
 .Xr intro 3monocypher
 .Sh HISTORY
-The
+.Fn crypto_verify
+first appeared in Monocypher 3.2.0.
+It replaced the
 .Fn crypto_verify16 ,
 .Fn crypto_verify32 ,
 .Fn crypto_verify64 ,
-functions first appeared in Monocypher 1.1.0.
+functions, which first appeared in Monocypher 1.1.0.
 They replaced the
 .Fn crypto_memcmp
 and

--- a/doc/man/man3/crypto_verify32.3monocypher
+++ b/doc/man/man3/crypto_verify32.3monocypher
@@ -1,1 +1,0 @@
-crypto_verify16.3monocypher

--- a/doc/man/man3/crypto_verify64.3monocypher
+++ b/doc/man/man3/crypto_verify64.3monocypher
@@ -1,1 +1,0 @@
-crypto_verify16.3monocypher

--- a/doc/man/man3/crypto_x25519.3monocypher
+++ b/doc/man/man3/crypto_x25519.3monocypher
@@ -128,7 +128,7 @@ If a protocol requires contributory behaviour,
 compare the output of
 .Fn crypto_x25519
 to an all-zero buffer using
-.Xr crypto_verify32 3monocypher ,
+.Xr crypto_verify 3monocypher ,
 then abort the protocol if the output and the all-zero buffer are equal.
 .Pp
 Do not use the same secret key for both key exchanges and signatures.

--- a/doc/man/man3/intro.3monocypher
+++ b/doc/man/man3/intro.3monocypher
@@ -115,10 +115,7 @@ implement EdDSA, with Curve25519 and BLAKE2b.
 This is the same as the more famous Ed25519, with SHA-512 replaced by
 the faster and more secure BLAKE2b.
 .Ss Constant time comparison
-.Xr crypto_verify16 3monocypher ,
-.Xr crypto_verify32 3monocypher ,
-and
-.Xr crypto_verify64 3monocypher
+.Xr crypto_verify 3monocypher ,
 compare buffers in constant time.
 They should be used to compare secrets to prevent timing attacks.
 .Ss Memory wipe
@@ -166,9 +163,7 @@ and
 .Xr crypto_sign_public_key 3monocypher ,
 .Xr crypto_unlock 3monocypher ,
 .Xr crypto_unlock_aead 3monocypher ,
-.Xr crypto_verify16 3monocypher ,
-.Xr crypto_verify32 3monocypher ,
-.Xr crypto_verify64 3monocypher ,
+.Xr crypto_verify 3monocypher ,
 .Xr crypto_wipe 3monocypher ,
 .Xr crypto_x25519 3monocypher ,
 .Xr crypto_x25519_dirty_fast 3monocypher ,
@@ -250,10 +245,7 @@ Nevertheless, there are a couple important caveats.
 .Pp
 Comparing secrets should be done with constant-time comparison
 functions, such as
-.Xr crypto_verify16 3monocypher ,
-.Xr crypto_verify32 3monocypher ,
-or
-.Xr crypto_verify64 3monocypher .
+.Xr crypto_verify 3monocypher .
 Do not use standard comparison functions.
 They tend to stop as soon as a difference is spotted.
 In many cases, this enables attackers to recover the secrets and

--- a/doc/man/man3/optional/crypto_hmac_sha512.3monocypher
+++ b/doc/man/man3/optional/crypto_hmac_sha512.3monocypher
@@ -157,13 +157,7 @@ performs
 and
 .Fn crypto_hmac_sha512_final .
 .Pp
-MACs may be truncated safely down to at most 16 bytes;
-the
-.Xr crypto_verify64 3monocypher ,
-.Xr crypto_verify32 3monocypher ,
-and
-.Xr crypto_verify16 3monocypher
-functions can be used to compare (possibly truncated) MACs.
+MACs may be truncated safely down to at most 16 bytes.
 .Sh RETURN VALUES
 These functions return nothing.
 .Sh EXAMPLES

--- a/doc/man/man3/optional/crypto_sha512.3monocypher
+++ b/doc/man/man3/optional/crypto_sha512.3monocypher
@@ -103,7 +103,7 @@ The
 .Xr crypto_hmac_sha512 3monocypher
 family of functions provides HMAC with SHA-512.
 Use
-.Xr crypto_verify64 3monocypher
+.Xr crypto_verify 3monocypher
 to compare MACs created this way.
 .Pp
 The arguments are:

--- a/doc/man2html.sh
+++ b/doc/man2html.sh
@@ -99,9 +99,7 @@ substitute() {
             -e 's|href="crypto_sign_public_key.html"|        href="../crypto_sign_public_key.html"|        '\
             -e 's|href="crypto_unlock_aead.html"|            href="../crypto_unlock_aead.html"|            '\
             -e 's|href="crypto_unlock.html"|                 href="../crypto_unlock.html"|                 '\
-            -e 's|href="crypto_verify16.html"|               href="../crypto_verify16.html"|               '\
-            -e 's|href="crypto_verify32.html"|               href="../crypto_verify32.html"|               '\
-            -e 's|href="crypto_verify64.html"|               href="../crypto_verify64.html"|               '\
+            -e 's|href="crypto_verify.html"|                 href="../crypto_verify.html"|               '\
             -e 's|href="crypto_wipe.html"|                   href="../crypto_wipe.html"|                   '\
             -e 's|href="crypto_x25519.html"|                 href="../crypto_x25519.html"|                 '\
             -e 's|href="crypto_chacha20_ctr.html"|                      href="../advanced/crypto_chacha20_ctr.html"|                    '\

--- a/src/monocypher.h
+++ b/src/monocypher.h
@@ -67,13 +67,10 @@ extern "C" {
 /// High level interface ///
 ////////////////////////////
 
-// Constant time comparisons
+// Constant time comparison
 // -------------------------
-
 // Return 0 if a and b are equal, -1 otherwise
-int crypto_verify16(const uint8_t a[16], const uint8_t b[16]);
-int crypto_verify32(const uint8_t a[32], const uint8_t b[32]);
-int crypto_verify64(const uint8_t a[64], const uint8_t b[64]);
+int crypto_verify(const uint8_t *a, const uint8_t *b, size_t size);
 
 
 // Erase sensitive data

--- a/tests/ctgrind.c
+++ b/tests/ctgrind.c
@@ -60,21 +60,21 @@ static void verify16()
 {
 	u8 a[16];
 	u8 b[16];
-	crypto_verify16(a, b);
+	crypto_verify(a, b, 16);
 }
 
 static void verify32()
 {
 	u8 a[32];
 	u8 b[32];
-	crypto_verify32(a, b);
+	crypto_verify(a, b, 32);
 }
 
 static void verify64()
 {
 	u8 a[64];
 	u8 b[64];
-	crypto_verify64(a, b);
+	crypto_verify(a, b, 64);
 }
 
 static void wipe()

--- a/tests/test.c
+++ b/tests/test.c
@@ -62,7 +62,7 @@
 ////////////////////////////////
 /// Constant time comparison ///
 ////////////////////////////////
-static void p_verify(size_t size, int (*compare)(const u8*, const u8*))
+static void p_verify(size_t size, int (*compare)(const u8*, const u8*, size_t))
 {
 	printf("\tcrypto_verify%zu\n", size);
 	u8 a[64]; // size <= 64
@@ -74,7 +74,7 @@ static void p_verify(size_t size, int (*compare)(const u8*, const u8*))
 				a[k] = (u8)i;
 				b[k] = (u8)j;
 			}
-			int cmp = compare(a, b);
+			int cmp = compare(a, b, size);
 			if (i == j) { ASSERT(cmp == 0); }
 			else        { ASSERT(cmp != 0); }
 			// Set only two bytes to the chosen value, then compare
@@ -85,7 +85,7 @@ static void p_verify(size_t size, int (*compare)(const u8*, const u8*))
 				}
 				a[k] = (u8)i; a[k + size/2 - 1] = (u8)i;
 				b[k] = (u8)j; b[k + size/2 - 1] = (u8)j;
-				cmp = compare(a, b);
+				cmp = compare(a, b, size);
 				if (i == j) { ASSERT(cmp == 0); }
 				else        { ASSERT(cmp != 0); }
 			}
@@ -95,9 +95,9 @@ static void p_verify(size_t size, int (*compare)(const u8*, const u8*))
 
 static void test_verify()
 {
-	p_verify(16, crypto_verify16);
-	p_verify(32, crypto_verify32);
-	p_verify(64, crypto_verify64);
+	p_verify(16, crypto_verify);
+	p_verify(32, crypto_verify);
+	p_verify(64, crypto_verify);
 }
 
 ////////////////

--- a/tests/tis-ci.c
+++ b/tests/tis-ci.c
@@ -325,7 +325,7 @@ static int p_x25519_inverse()
 }
 
 //@ ensures \result == 0;
-static int p_verify(size_t size, int (*compare)(const u8*, const u8*))
+static int p_verify(size_t size, int (*compare)(const u8*, const u8*, size_t))
 {
 	int status = 0;
 	u8 a[64]; // size <= 64
@@ -337,7 +337,7 @@ static int p_verify(size_t size, int (*compare)(const u8*, const u8*))
 				a[k] = (u8)i;
 				b[k] = (u8)j;
 			}
-			int cmp = compare(a, b);
+			int cmp = compare(a, b, size);
 			status |= (i == j ? cmp : ~cmp);
 			// Set only two bytes to the chosen value, then compare
 			FOR (k, 0, size / 2) {
@@ -347,7 +347,7 @@ static int p_verify(size_t size, int (*compare)(const u8*, const u8*))
 				}
 				a[k] = (u8)i; a[k + size/2 - 1] = (u8)i;
 				b[k] = (u8)j; b[k + size/2 - 1] = (u8)j;
-				cmp = compare(a, b);
+				cmp = compare(a, b, size);
 				status |= (i == j ? cmp : ~cmp);
 			}
 		}
@@ -356,11 +356,11 @@ static int p_verify(size_t size, int (*compare)(const u8*, const u8*))
 	return status;
 }
 //@ ensures \result == 0;
-static int p_verify16(){ return p_verify(16, crypto_verify16); }
+static int p_verify16(){ return p_verify(16, crypto_verify); }
 //@ ensures \result == 0;
-static int p_verify32(){ return p_verify(32, crypto_verify32); }
+static int p_verify32(){ return p_verify(32, crypto_verify); }
 //@ ensures \result == 0;
-static int p_verify64(){ return p_verify(64, crypto_verify64); }
+static int p_verify64(){ return p_verify(64, crypto_verify); }
 
 #define TEST(name)                                                      \
 	int v_##name() { \


### PR DESCRIPTION
Allows `crypto_verify` to work with buffers of arbitrary size.