### PR TITLE
Manual fixes and a copyright note

### DIFF
--- a/doc/crypto_argon2.3monocypher
+++ b/doc/crypto_argon2.3monocypher
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd January 22, 2023
+.Dd February 25, 2023
 .Dt CRYPTO_ARGON2 3MONOCYPHER
 .Os
 .Sh NAME
@@ -112,7 +112,7 @@ It must be
 .Fa config.nb_blocks
 × 1024 bytes big and suitably aligned for 64-bit integers.
 If you are not sure how to allocate that buffer, just use
-.Xr malloc 3.
+.Xr malloc 3 .
 .Pp
 The work area is automatically wiped by
 .Fn crypto_argon2 .
@@ -275,7 +275,7 @@ instances in parallel:
 each instance gets a different thread number as additional data,
 generating as many independent digests as we need.
 We can then hash those digests with
-.Xr crypto_blake2b .
+.Xr crypto_blake2b 3monocypher .
 .It Fa ad_size
 Length of
 .Fa ad ,

--- a/doc/crypto_blake2b.3monocypher
+++ b/doc/crypto_blake2b.3monocypher
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd February 02, 2023
+.Dd February 2, 2023
 .Dt CRYPTO_BLAKE2B 3MONOCYPHER
 .Os
 .Sh NAME

--- a/doc/crypto_chacha20_djb.3monocypher
+++ b/doc/crypto_chacha20_djb.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019, 2023 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2017, 2019-2021 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2021, 2023 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -50,7 +50,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd January 26, 2023
+.Dd February 25, 2023
 .Dt CRYPTO_CHACHA20 3MONOCYPHER
 .Os
 .Sh NAME
@@ -220,7 +220,6 @@ Additionally, it
 .Em can
 be used to generate large amounts of random-looking data quickly
 \(en for example to generate padding.
-.Pp
 .Sh RETURN VALUES
 .Fn crypto_chacha20_djb ,
 .Fn crypto_chacha20_ietf ,
@@ -410,7 +409,7 @@ in
 .Sy undefined behaviour .
 Make sure your inputs are correct.
 .Sh SECURITY CONSIDERATIONS
-.Ss Encrypted does not mean secure .
+.Ss Encrypted does not mean secure
 ChaCha20 only protects against eavesdropping, not forgeries.
 Most applications need protection against forgeries to be properly
 secure.

--- a/doc/crypto_ed25519_sign.3monocypher
+++ b/doc/crypto_ed25519_sign.3monocypher
@@ -8,7 +8,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Copyright (c) 2019-2020, 2022 Fabio Scotoni
+.\" Copyright (c) 2019-2020, 2022-2023 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -38,7 +38,7 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Written in 2019-2020 and 2022 by Fabio Scotoni
+.\" Written in 2019-2020 and 2022-2023 by Fabio Scotoni
 .\"
 .\" To the extent possible under law, the author(s) have dedicated all copyright
 .\" and related neighboring rights to this software to the public domain
@@ -48,14 +48,14 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd February 13, 2022
+.Dd February 25, 2022
 .Dt CRYPTO_ED25519_SIGN 3MONOCYPHER
 .Os
 .Sh NAME
 .Nm crypto_ed25519_sign ,
 .Nm crypto_ed25519_check ,
-.Nm crypto_ed25519_key_pair
-.Nm crypto_ed25519_ph_sign
+.Nm crypto_ed25519_key_pair ,
+.Nm crypto_ed25519_ph_sign ,
 .Nm crypto_ed25519_ph_check
 .Nd public key signatures
 .Sh SYNOPSIS

--- a/doc/crypto_eddsa_sign.3monocypher
+++ b/doc/crypto_eddsa_sign.3monocypher
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2017-2019, 2022-2023 Loup Vaillant
 .\" Copyright (c) 2017-2018 Michael Savage
-.\" Copyright (c) 2017, 2019-2022 Fabio Scotoni
+.\" Copyright (c) 2017, 2019-2023 Fabio Scotoni
 .\" All rights reserved.
 .\"
 .\"
@@ -50,18 +50,18 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd February 19, 2023
+.Dd February 25, 2023
 .Dt CRYPTO_SIGN 3MONOCYPHER
 .Os
 .Sh NAME
-.Nm crypto_eddsa_sign
-.Nm crypto_eddsa_check
-.Nm crypto_eddsa_key_pair
-.Nm crypto_eddsa_to_x25519
-.Nm crypto_eddsa_trim_scalar
-.Nm crypto_eddsa_reduce
-.Nm crypto_eddsa_mul_add
-.Nm crypto_eddsa_scalarbase
+.Nm crypto_eddsa_sign ,
+.Nm crypto_eddsa_check ,
+.Nm crypto_eddsa_key_pair ,
+.Nm crypto_eddsa_to_x25519 ,
+.Nm crypto_eddsa_trim_scalar ,
+.Nm crypto_eddsa_reduce ,
+.Nm crypto_eddsa_mul_add ,
+.Nm crypto_eddsa_scalarbase ,
 .Nm crypto_eddsa_check_equation
 .Nd public key signatures
 .Sh SYNOPSIS
@@ -180,7 +180,6 @@ a key exchange protocol involving
 and then
 .Xr crypto_aead_lock 3monocypher
 instead.
-.Pp
 .Ss Conversion to X25519
 .Fn crypto_eddsa_to_x25519
 Converts and EdDSA public key to an X25519 public key.
@@ -244,11 +243,11 @@ coordinate in Little Endian.
 .Pp
 .Fn crypto_eddsa_check_equation
 reads a signature
-.Fa Rs ,
+.Fa \&Rs ,
 a public_key
 .Fa A ,
 and hash
-.Fa h,
+.Fa h ,
 then checks the following:
 .Bl -dash
 .It

--- a/doc/crypto_sha512.3monocypher
+++ b/doc/crypto_sha512.3monocypher
@@ -8,8 +8,8 @@
 .\"
 .\" ----------------------------------------------------------------------------
 .\"
-.\" Copyright (c) 2019-2020 Fabio Scotoni
-.\" Copyright (c) 2023      Loup Vaillant
+.\" Copyright (c) 2019-2020, 2023 Fabio Scotoni
+.\" Copyright (c) 2023            Loup Vaillant
 .\" All rights reserved.
 .\"
 .\"
@@ -49,7 +49,7 @@
 .\" with this software.  If not, see
 .\" <https://creativecommons.org/publicdomain/zero/1.0/>
 .\"
-.Dd February 5, 2020
+.Dd February 25, 2023
 .Dt CRYPTO_SHA512 3MONOCYPHER
 .Os
 .Sh NAME
@@ -340,7 +340,7 @@ is zero.
 Otherwise it should contain at least 16 bytes.
 .It Fa salt_size
 Length of
-.Fa salt,
+.Fa salt ,
 in bytes.
 .It Fa info
 Optional domain separation string for key derivation.

--- a/makefile
+++ b/makefile
@@ -100,6 +100,7 @@ install: library src/monocypher.h monocypher.pc install-doc
             > $(DESTDIR)/$(PKGCONFIGDIR)/monocypher.pc
 
 install-doc:
+	doc/doc_gen.sh
 	mkdir -p $(DESTDIR)/$(MANDIR)
 	cp -PR doc/man3/*.3monocypher $(DESTDIR)/$(MANDIR)
 


### PR DESCRIPTION
I cleaned out some leftover lint from the documentation overhaul; details in the respective commit messages.

The \& in crypto_eddsa_sign.3monocypher because Rs gets parsed as a non-existent macro otherwise and thus removed out of existence

@LoupVaillant `crypto_ed25519_sign.3monocypher` needs your copyright after merging because you copied the UB caveat everywhere