### PR TITLE
Update crypto_argon2.3monocypher - fixes errors and warnings that can lead to the incorrect solution

### DIFF
--- a/doc/crypto_argon2.3monocypher
+++ b/doc/crypto_argon2.3monocypher
@@ -341,11 +341,11 @@ crypto_argon2_config config = {
     .nb_passes = 3,                          /* 3 iterations    */
     .nb_lanes  = 1                           /* Single-threaded */
 };
-uint8_t password[14] = "Okay Password!";
+uint8_t password[] = "Okay Password!";
 crypto_argon2_inputs inputs = {
-    .pass      = password,                     /* User password */
-    .pass_size = sizeof(password),           /* Password length */
+    .pass      = password,                   /* User password */
     .salt      = salt,                 /* Salt for the password */
+    .pass_size = sizeof(password) - 1,       /* Password length */
     .salt_size = 16
 };
 crypto_argon2_extras extras = {0};   /* Extra parameters unused */
@@ -367,6 +367,8 @@ if (work_area == NULL) {
     crypto_wipe(password, sizeof(password));
     free(work_area);
 }
+
+
 .Ed
 .Sh SEE ALSO
 .Xr crypto_aead_lock 3monocypher ,


### PR DESCRIPTION
Closes: #264 

Fixes these issues, by allowing password array to autosize, and then making sure to drop the \0 character when determining the size of the string, and also reorders the crypto_argon2_inputs field designators to remove a warning.

```
main.cpp:83:24: error: initializer-string for char array is too long, array size is 14 but initializer has size 15 (including the null terminating character)
uint8_t password[14] = "Okay Password!";
                       ^~~~~~~~~~~~~~~~
main.cpp:87:5: warning: ISO C++ requires field designators to be specified in declaration order; field 'pass_size' will be initialized after field 'salt' [-Wreorder-init-list]
    .salt      = salt,                 /* Salt for the password */
    ^~~~~~~~~~~~~~~~~
```