### PR TITLE
Had to change soname to install_name on macos, but I don't really know why

### DIFF
--- a/makefile
+++ b/makefile
@@ -132,7 +132,7 @@ lib/libmonocypher.so: lib/$(SONAME)
 	ln -sf `basename lib/$(SONAME)` $@
 
 lib/$(SONAME): $(MAIN_O)
-	$(CC) $(CFLAGS) $(LDFLAGS) -shared -Wl,-soname,$(SONAME) -o $@ $(MAIN_O)
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared -Wl,-install_name,$(SONAME) -o $@ $(MAIN_O)
 
 lib/monocypher.o: src/monocypher.c src/monocypher.h
 	@mkdir -p $(@D)


### PR DESCRIPTION
Was getting this error:
```
$ make
cc -pedantic -Wall -Wextra -O3 -march=native -L/opt/homebrew/opt/llvm/lib -shared -Wl,-soname,libmonocypher.so.4 -o lib/libmonocypher.so.4 lib/monocypher.o lib/monocypher-ed25519.o
ld: unknown options: -soname
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [lib/libmonocypher.so.4] Error 1
```

And someone on stackoverflow said to change soname to install_name, so I did that:
https://stackoverflow.com/questions/4580789/ld-unknown-option-soname-on-os-x


And it worked! But not very scientific and could have downsides.. But figured I'd let ya know.

-	$(CC) $(CFLAGS) $(LDFLAGS) -shared -Wl,-soname,$(SONAME) -o $@ $(MAIN_O)
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared -Wl,-install_name,$(SONAME) -o $@ $(MAIN_O)