### PR TITLE
Windows and Darwin support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@
 *.a
 *.so
 *.so.*
+*.dll
+*.dylib
 *.out
+*.out.exe
 *.vec
 *.gch
 *.sav

--- a/tests/gen/makefile
+++ b/tests/gen/makefile
@@ -49,8 +49,14 @@
 # You should have received a copy of the CC0 Public Domain Dedication along
 # with this software.  If not, see
 # <https://creativecommons.org/publicdomain/zero/1.0/>
-CC     ?= gcc -std=c99
-CFLAGS ?= -pedantic -Wall -Wextra
+
+CC       ?= gcc -std=c99
+CFLAGS   ?= -pedantic -Wall -Wextra
+ifeq ($(OS),Windows_NT)
+EXESUFFIX = .exe
+else
+EXESUFFIX =
+endif
 
 .PHONY: all clean
 
@@ -67,7 +73,7 @@ VECTORS = ../vectors.h
 all: $(VECTORS)
 
 clean:
-	rm -f *.out *.vec *.o
+	rm -f *.out$(EXESUFFIX) *.vec *.o
 	rm -f $(VECTORS)
 
 elligator_inv.vec: elligator-inverse.py elligator.py elligator_scalarmult.py
@@ -76,7 +82,7 @@ elligator_dir.vec: elligator-direct.py elligator.py
 	./$< >$@
 sha512_hkdf.vec: sha512_hkdf.py
 	./$< >$@
-%.vec: %.out
+%.vec: %.out$(EXESUFFIX)
 	./$< > $@
 
 utils.o: utils.c utils.h
@@ -90,7 +96,7 @@ utils.o: utils.c utils.h
             -I ../../src/optional          \
             $$(pkg-config --cflags libsodium)
 
-%.out: %.o ed25519.o utils.o
+%.out$(EXESUFFIX): %.o ed25519.o utils.o
 	$(CC) $(CFLAGS) -o $@ $^ \
             $$(pkg-config --libs libsodium)
 
@@ -105,7 +111,7 @@ ed25519.o: ../externals/ed25519-donna/ed25519.c \
             -DED25519_NO_INLINE_ASM           \
             -DED25519_FORCE_32BIT
 
-vector_to_header.out: vector_to_header.c
+vector_to_header.out$(EXESUFFIX): vector_to_header.c
 	$(CC) $(CFLAGS) $< -o $@
 
 chacha20.all.vec      : chacha20.vec      vectors/chacha20
@@ -134,8 +140,8 @@ $(VEC2):
 	mkdir -p $(@D)
 	cat $^ > $@
 
-%.h.vec: %.all.vec vector_to_header.out
-	./vector_to_header.out  $(patsubst %.all.vec,%,$<) < $< > $@
+%.h.vec: %.all.vec vector_to_header.out$(EXESUFFIX)
+	./vector_to_header.out$(EXESUFFIX)  $(patsubst %.all.vec,%,$<) < $< > $@
 
 prelude.h.vec:
 	@echo "creating prelude.h.vec"

--- a/tests/speed/makefile
+++ b/tests/speed/makefile
@@ -49,8 +49,13 @@
 # with this software.  If not, see
 # <https://creativecommons.org/publicdomain/zero/1.0/>
 
-CC     ?= gcc -std=gnu99
-CFLAGS ?= -pedantic -Wall -Wextra -O3 -march=native
+CC       ?= gcc -std=gnu99
+CFLAGS   ?= -pedantic -Wall -Wextra -O3 -march=native
+ifeq ($(OS),Windows_NT)
+EXESUFFIX = .exe
+else
+EXESUFFIX =
+endif
 
 .PHONY: speed speed-sodium speed-hydrogen speed-tweetnacl speed-c25519 \
         speed-donna \
@@ -62,23 +67,23 @@ CFLAGS ?= -pedantic -Wall -Wextra -O3 -march=native
 ##################
 all: speed
 
-speed          : speed.out
+speed          : speed.out$(EXESUFFIX)
 	./$<
-speed-sodium   : speed-sodium.out
+speed-sodium   : speed-sodium.out$(EXESUFFIX)
 	./$<
-speed-hydrogen : speed-hydrogen.out
+speed-hydrogen : speed-hydrogen.out$(EXESUFFIX)
 	./$<
-speed-tweetnacl: speed-tweetnacl.out
+speed-tweetnacl: speed-tweetnacl.out$(EXESUFFIX)
 	./$<
-speed-c25519   : speed-c25519.out
+speed-c25519   : speed-c25519.out$(EXESUFFIX)
 	./$<
-speed-donna    : speed-donna.out
+speed-donna    : speed-donna.out$(EXESUFFIX)
 	./$<
-speed-tinyssh  : speed-tinyssh.out
+speed-tinyssh  : speed-tinyssh.out$(EXESUFFIX)
 	./$<
 
 clean:
-	rm -f *.o *.out
+	rm -f *.o *.out$(EXESUFFIX)
 
 ####################
 ## Base libraries ##
@@ -186,23 +191,23 @@ speed-donna.o     : speed-donna.c     speed.h ../utils.h $(DONNA_HEADERS)
 speed-tinyssh.o   : speed-tinyssh.c   speed.h ../utils.h $(TSSH_H)
 	$(CC) -c $(CFLAGS) $< -o $@ -I .. -I $(TSSH)
 
-speed.out: speed.o utils.o monocypher.o monocypher-ed25519.o
+speed.out$(EXESUFFIX): speed.o utils.o monocypher.o monocypher-ed25519.o
 	$(CC) $(CFLAGS) -o $@ $^
-speed-sodium.out: speed-sodium.o utils.o
+speed-sodium.out$(EXESUFFIX): speed-sodium.o utils.o
 	$(CC) $(CFLAGS) -o $@ $^            \
 	    `pkg-config --cflags libsodium` \
 	    `pkg-config --libs   libsodium`
-speed-donna.out: speed-donna.o donna.o utils.o
+speed-donna.out$(EXESUFFIX): speed-donna.o donna.o utils.o
 	$(CC) $(CFLAGS) -o $@ $^            \
 	    `pkg-config --cflags libsodium` \
 	    `pkg-config --libs   libsodium`
-speed-hydrogen.out: speed-hydrogen.o utils.o
+speed-hydrogen.out$(EXESUFFIX): speed-hydrogen.o utils.o
 	$(CC) $(CFLAGS) -o $@ $^              \
 	    `pkg-config --cflags libhydrogen` \
 	    `pkg-config --libs   libhydrogen`
-speed-tweetnacl.out: speed-tweetnacl.o tweetnacl.o utils.o
+speed-tweetnacl.out$(EXESUFFIX): speed-tweetnacl.o tweetnacl.o utils.o
 	$(CC) $(CFLAGS) -o $@ $^
-speed-c25519.out   : speed-c25519.o $(C25519_OBJECTS) utils.o
+speed-c25519.out$(EXESUFFIX)   : speed-c25519.o $(C25519_OBJECTS) utils.o
 	$(CC) $(CFLAGS) -o $@ $^
-speed-tinyssh.out : speed-tinyssh.o $(TSSH_O) utils.o
+speed-tinyssh.out$(EXESUFFIX) : speed-tinyssh.o $(TSSH_O) utils.o
 	$(CC) $(CFLAGS) -o $@ $^


### PR DESCRIPTION
The current makefile is not portable. These changes will allow to compile the library under Windows (cygwin/MinGW/MSYS) and Darwin.
Tested with cygwin, MinGW, MSYS2, macOS Sonoma, Debian
