### PR TITLE
Fix conversion warnings in ed25519 (store64_be).

### DIFF
--- a/src/optional/monocypher-ed25519.c
+++ b/src/optional/monocypher-ed25519.c
@@ -93,14 +93,14 @@ static u64 load64_be(const u8 s[8])
 
 static void store64_be(u8 out[8], u64 in)
 {
-	out[0] = (in >> 56) & 0xff;
-	out[1] = (in >> 48) & 0xff;
-	out[2] = (in >> 40) & 0xff;
-	out[3] = (in >> 32) & 0xff;
-	out[4] = (in >> 24) & 0xff;
-	out[5] = (in >> 16) & 0xff;
-	out[6] = (in >>  8) & 0xff;
-	out[7] =  in        & 0xff;
+	out[0] = (u8)((in >> 56) & 0xff);
+	out[1] = (u8)((in >> 48) & 0xff);
+	out[2] = (u8)((in >> 40) & 0xff);
+	out[3] = (u8)((in >> 32) & 0xff);
+	out[4] = (u8)((in >> 24) & 0xff);
+	out[5] = (u8)((in >> 16) & 0xff);
+	out[6] = (u8)((in >>  8) & 0xff);
+	out[7] = (u8)( in        & 0xff);
 }
 
 static void load64_be_buf (u64 *dst, const u8 *src, size_t size) {


### PR DESCRIPTION
Similar to my earlier patch, i found additional conversion warnings in ed25519. It is noteworthy that *only* [line 96](https://github.com/LoupVaillant/Monocypher/blob/9712c5b360f31bd5d30bdffa9945ce8e84c18cc9/src/optional/monocypher-ed25519.c#L96) (the rshift 56 mask 0xFF) actually produces a warning, the rest passes without complaint. I am unsure why this is.

This patch applies explicit conversion to all rows in this function, even the seemingly unproblematic ones, which seems reasonable to me. It is unclear to me if this is formatted to your taste standards. Maybe you would drop the surrounding parens (untested), but I'll leave that up to you. 

One could get away with only casting the first shift, however I don't see why GCC is not warning about the others. Might be missing something obvious.

The entirety of Monocypher now builds cleanly with -Wconversion on GCC. *Passes all tests.*

gcc (GCC) 15.2.1 20260123 (Red Hat 15.2.1-7), glibc, Fedora 43

Thanks & godspeed